### PR TITLE
ci: release to npm via workflow; 0.2.0-alpha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release to npm
+
+run-name: Release ${{ inputs.version || github.ref_name }} to npm${{ inputs.dry_run && ' (dry-run)' || '' }}
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to publish (e.g. 0.2.0-alpha). Leave empty to use package.json.
+        required: false
+        type: string
+      dry_run:
+        description: Build and verify without publishing
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dsh-univer-office-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Set version
+        id: version
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            pnpm version ${{ inputs.version }} --no-git-tag-version
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Pack and inspect
+        run: |
+          npm pack --dry-run
+          test -f dist/.npmignore || true
+
+      - name: Publish to npm
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if [[ "$VERSION" == *"-"* ]]; then
+            NPM_TAG="alpha"
+          else
+            NPM_TAG="latest"
+          fi
+          npm publish --access public --tag "$NPM_TAG"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## Release ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- dry-run: ${{ inputs.dry_run }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- published: ${{ inputs.dry_run && 'no' || 'yes' }}" >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-univer-office",
-  "version": "0.2.0",
+  "version": "0.2.0-alpha",
   "description": "DSH × Univer integration with a bundled collaboration Gateway and Viewer: inline previews, live floating Worktree windows, and session-end review actions in DeepSeek Harness.",
   "type": "module",
   "main": "./lib/index.js",
@@ -74,7 +74,8 @@
     "test:integration": "node test/integration-smoke.mjs",
     "test:host": "node test/host-smoke.mjs",
     "test:client": "node test/client-smoke.mjs",
-    "test": "pnpm run build && pnpm run test:host && pnpm run test:integration && pnpm run test:client"
+    "test": "pnpm run build && pnpm run test:host && pnpm run test:integration && pnpm run test:client",
+    "prepublishOnly": "pnpm run build && pnpm run test"
   },
   "dependencies": {
     "@univerjs-pro/cli-assets": "0.1.0",


### PR DESCRIPTION
## Summary

Add a GitHub Actions release pipeline for `dsh-univer-office`, and set version `0.2.0-alpha`.

### Release workflow (`.github/workflows/release.yml`)
- **Triggers**: `workflow_dispatch` (manual, with `version` + `dry_run` inputs) or push of a `v*` tag
- **Steps**: checkout → pnpm install (frozen lockfile) → build (lib+worker+gateway from src) → test (host+integration+client smokes) → `npm publish --access public` to registry.npmjs.org
- **npm tag**: `alpha` for prerelease versions (contains `-`), `latest` otherwise
- **Safety**: `dry_run` default true; publish only when explicitly disabled

### Safety net
- `prepublishOnly: pnpm run build && pnpm run test` — publishing an unbuilt/stale package fails fast

### Version
- `0.2.0-alpha` — first publishable prerelease of the source-built SDK application

## How to release
1. Merge this PR
2. Add repo secret `NPM_TOKEN` (npm automation token with publish scope)
3. Trigger "Release to npm" manually with `version=0.2.0-alpha`, `dry_run=false` — or push a `v0.2.0-alpha` tag

## Verified locally
- `pnpm install --frozen-lockfile` ✅
- `prepublishOnly` (build + test): all three smokes pass ✅
- `npm pack --dry-run`: `dsh-univer-office-0.2.0-alpha.tgz`, 22.4MB, 259 files ✅