### PR TITLE
ci: pin pnpm version via packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,5 +126,6 @@
     "@univerjs-pro/bases": "1.0.0-insiders.20260813-7c9aa50",
     "@univerjs-pro/collaboration-endpoint": "1.0.0-insiders.20260813-7c9aa50",
     "@univerjs-pro/collaboration-worktree-endpoint": "1.0.0-insiders.20260813-7c9aa50"
-  }
+  },
+  "packageManager": "pnpm@11.20.0"
 }


### PR DESCRIPTION
pnpm/action-setup failed with 'No pnpm version is specified'. Declare `packageManager: pnpm@11.20.0` (matching the lockfile) so the release workflow resolves the pnpm version automatically.