### PR TITLE
fix: installer idempotency checks by entry id, not package name

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ done
 echo "   ✅ Plugin files installed"
 
 # 2. Write the loader entry (idempotent; keeps cordis.patch.yml valid YAML)
-if ! grep -q "name: 'dsh-univer-office'" "$PATCH" 2>/dev/null; then
+if ! grep -qE "^\s*- id: univer" "$PATCH" 2>/dev/null; then
   mkdir -p "$(dirname "$PATCH")"
   # Drop a lone empty-array template line ("[]") so appending the insert entry
   # below stays a valid top-level YAML array (the profile template ships as `[]`).

--- a/packaging/install.command
+++ b/packaging/install.command
@@ -27,7 +27,7 @@ cp -R "$(dirname "$0")/univer" "$DEST"
 echo "✅ Step 1/3: plugin files installed"
 
 # 3. Write the loader entry (idempotent; keeps cordis.patch.yml valid YAML)
-if ! grep -q "name: 'dsh-univer-office'" "$PATCH" 2>/dev/null; then
+if ! grep -qE "^\s*- id: univer" "$PATCH" 2>/dev/null; then
   mkdir -p "$(dirname "$PATCH")"
   # Drop a lone empty-array template line ("[]") so the appended entry below
   # stays a valid top-level YAML array (the profile template ships as `[]`).


### PR DESCRIPTION
## Problem

`install.sh` (and `packaging/install.command`) only skipped appending the loader entry when the **new package name** (`dsh-univer-office`) was already in `cordis.patch.yml`. If the patch carried any other univer row — the old `@dsh-local/univer`, or a user's own `id: univer` entry — the installer appended a **second `id: univer`** pointing at the new package. Two entries with the same `id` make the loader fight over which one wins.

## Fix

Check for an existing **`id: univer`** entry instead of the package name. Whatever the package name, never append a second univer row. The append remains append-only and the `[]` template line is still stripped first, so other entries in the patch (e.g. a user's `tps-meter`) are preserved.

## Verified

| Patch state | Result |
|---|---|
| contains old `@dsh-local/univer` + `tps-meter` | ✅ no append (id present) |
| empty template `[]` | ✅ appends |
| contains new `dsh-univer-office` | ✅ no append |
| empty file | ✅ appends |

Note: a full profile rebuild by `dsh plugin add` (which regenerates the whole profile including the patch) is DSH's own behavior and out of scope here.