### PR TITLE
fix: align Chart Skills with current Facade

### DIFF
--- a/skills/univer-board/SKILL.md
+++ b/skills/univer-board/SKILL.md
@@ -7,7 +7,9 @@ description: Create, edit, chart, inspect, and review Univer Board canvas Units 
 
 Load `univer` first. Create the Board with `univer_unit` in a draft worktree and retain its `unitId`. `univer_execute` provides `univerAPI`, `api`, and the selected `FBoard` as `board`; do not redeclare them.
 
-Resolve exact methods with `univer_api`, especially `FBoard.insertShape`, `FBoard.insertShapes`, `FShape`, connector methods, and `FBoardCharts`.
+Resolve exact methods with `univer_api`, especially `FBoard.insertShape`, `FBoard.insertShapes`,
+`FShape`, connector methods, `FBoard.newChart`, `FBoard.insertChart`, `FBoard.getCharts`, and
+`FBoard.getChart`.
 
 ```js
 const shape = board.insertShape({
@@ -73,15 +75,14 @@ Do not use Unicode glyphs as a substitute for required icons or illustrations. D
 
 ## Native charts
 
-Native Board charts use `board.charts` (`FBoardCharts`). Build a detached chart, configure its data and canvas geometry, then await insertion:
+Native Board charts are owned directly by `FBoard`. Build detached chart information, then await
+insertion to obtain a live `FBoardChart`:
 
 ```js
-const charts = board.charts;
-const chart = charts
-  .create()
-  .setType(univerAPI.Enum.ChartTypeString.Column)
+const info = board
+  .newChart(univerAPI.Enum.ChartTypeString.Column)
   .setTitle({ text: "Quarterly Revenue" })
-  .setData([
+  .setSource([
     ["Quarter", "Revenue"],
     ["Q1", 12],
     ["Q2", 18],
@@ -89,15 +90,22 @@ const chart = charts
   ])
   .setCategoryField(0)
   .setValueFields([1])
-  .setPosition(80, 80)
-  .setSize(640, 360);
-const inserted = await charts.insert(chart);
-return { chartId: inserted.getId(), chart: inserted.describe() };
+  .setAbsolutePosition(80, 80)
+  .setSize(640, 360)
+  .build();
+const inserted = await board.insertChart(info);
+return { chartId: inserted.getId(), info: inserted.getInfo(), data: inserted.getDataSource() };
 ```
 
-Builders returned by `charts.list()` or `charts.get(id)` are host-bound. Update with `setData(values).commit()`. Remove with `await charts.remove(chartOrId)` and check the boolean. Await insert/remove before execution returns.
+`board.getCharts()` and `board.getChart(id)` return live charts. Common setters update the live
+chart; await `chart.setDataSource(values)` for data changes. For a complete replacement, use
+`chart.toBuilder().build()` and `await chart.update(info)`. Remove it with `await chart.remove()`
+and check the boolean. Await insertion, data updates, replacement, and removal before execution
+returns.
 
-Verify in a later read-only execution with `board.charts.list().map((item) => item.describe())`, confirming ID, count, type, title, position, size, and data.
+Verify in a later read-only execution with
+`board.getCharts().map((item) => ({ id: item.getId(), type: item.getType(), info: item.getInfo(), data: item.getDataSource() }))`,
+confirming ID, count, type, title, position, size, and data.
 
 ## Verification
 

--- a/skills/univer-doc/SKILL.md
+++ b/skills/univer-doc/SKILL.md
@@ -16,7 +16,8 @@ Select paragraphs with `doc.getParagraphs()` and `doc.getParagraph(paragraphId)`
 - Paragraph IDs are stable across multi-step edits; indexes drift as content changes.
 - `FDocumentParagraph` supports `getText`, `setText`, `appendText`, `setStyle`, and `getRange`.
 - Lists and task helpers include `isListItem`, `isTask`, and `setTaskChecked`.
-- Native charts use the document-owned `doc.charts` collection.
+- Native charts use the direct `doc.newChart()`, `doc.insertChart()`, `doc.getCharts()`, and
+  `doc.getChart()` methods.
 - Colors must use `#RRGGBB`. Docs do not support formulas or recalculation.
 
 ## Data stream
@@ -105,16 +106,15 @@ Constrain cell-local paragraph edits with `table.getCellContentRange(row, column
 
 ## Native charts
 
-Create and manage data-driven charts through `doc.charts`. Query `FDocumentCharts`, `FDocumentChartBuilder`, and `DocChartInsertAnchorKind` before authoring.
+Create detached chart information directly from `doc`, then insert it to obtain a live
+`FDocumentChart`. Query `FDocument.newChart`, `FDocument.insertChart`, `FDocument.getCharts`,
+`FDocument.getChart`, `FDocumentChartBuilderOf`, and `DocsChartInsertAnchorKind` before authoring.
 
 ```js
-const charts = doc.charts;
-const chart = charts
-  .create()
-  .setType(univerAPI.Enum.ChartTypeString.Column)
-  .setTitle({ text: "Quarterly Revenue" });
-chart
-  .setData([
+const info = doc
+  .newChart(univerAPI.Enum.ChartTypeString.Column)
+  .setTitle({ text: "Quarterly Revenue" })
+  .setSource([
     ["Quarter", "Revenue"],
     ["Q1", 12],
     ["Q2", 18],
@@ -122,13 +122,20 @@ chart
   ])
   .setCategoryField(0)
   .setValueFields([1])
-  .setAnchor({ kind: univerAPI.Enum.DocChartInsertAnchorKind.BodyOffset, offset: 0 })
-  .setLayout({ width: 480, height: 320 });
-const inserted = await charts.insert(chart);
-return { chartId: inserted.getId(), chart: inserted.describe() };
+  .setPosition({ kind: univerAPI.Enum.DocsChartInsertAnchorKind.BodyOffset, offset: 0 })
+  .setInline()
+  .setSize(480, 320)
+  .build();
+const inserted = await doc.insertChart(info);
+return { chartId: inserted.getId(), drawingId: inserted.getDrawingId(), info: inserted.getInfo() };
 ```
 
-Update a bound builder with `setData(values).commit()`. Remove with `await charts.remove(chartOrId)` and check the boolean. Await insertion/removal before execution returns. Verify in a fresh read-only execution with `doc.charts.list().map((item) => item.describe())`.
+`doc.getCharts()` and `doc.getChart(id)` return live charts. Await
+`chart.setDataSource(values)` for data changes. For a complete replacement, use
+`chart.toBuilder().build()` and `await chart.update(info)`. Remove it with `await chart.remove()`
+and check the boolean. Await every asynchronous mutation before execution returns. Verify in a
+fresh read-only execution with
+`doc.getCharts().map((item) => ({ id: item.getId(), drawingId: item.getDrawingId(), type: item.getType(), info: item.getInfo() }))`.
 
 ## Inspect and verify
 

--- a/skills/univer-slide/SKILL.md
+++ b/skills/univer-slide/SKILL.md
@@ -13,7 +13,8 @@ Facade page indexes are zero-based (`getSlideByIndex`, `getSlides()[i]`). Tool p
 
 - Create or redesign a page: author SVG and call `univer_compile_svg`. Do not hand-write Facade drawing calls for generated page content.
 - Edit existing content: use `univer_execute` with live Facade handles.
-- Insert or update native charts: reserve the rectangle in the page SVG, then use `slide.charts` through `univer_execute`.
+- Insert or update native charts: reserve the rectangle in the page SVG, then use the direct
+  `FSlide` chart methods through `univer_execute`.
 - Verify every changed page: `univer_inspect`, then `univer_lint`, then review the live DSH preview.
 - Export only after verification: `univer_export` to `.pptx`.
 
@@ -197,17 +198,15 @@ The reorder command requires the complete order. A partial list moves listed ele
 
 ## Native charts
 
-Create charts through `slide.charts`. Build detached, configure data and geometry, then await insertion:
+Create detached chart information directly from the slide, call `.build()`, then await
+`slide.insertChart(info)` to obtain a live `FSlideChart`:
 
 ```js
 const slide = presentation.getSlideByIndex(0);
-const charts = slide.charts;
-const chart = charts
-  .create()
-  .setType(univerAPI.Enum.ChartTypeString.Donut)
-  .setTitle({ text: "Design Elements" });
-chart
-  .setData([
+const info = slide
+  .newChart(univerAPI.Enum.ChartTypeString.Donut)
+  .setTitle({ text: "Design Elements" })
+  .setSource([
     ["Design element", "Share"],
     ["Color", 30],
     ["Composition", 22],
@@ -217,12 +216,19 @@ chart
   .setDoughnutHole(0.46)
   .setLegend(true)
   .setAbsolutePosition(390, 160)
-  .setSize(260, 220);
-const inserted = await charts.insert(chart);
-return { chartId: inserted.getId(), chart: inserted.describe() };
+  .setSize(260, 220)
+  .build();
+const inserted = await slide.insertChart(info);
+return { chartId: inserted.getId(), info: inserted.getInfo(), resource: inserted.getChartData() };
 ```
 
-Update a host-bound chart with `setData(values).commit()`. Remove with `await charts.remove(chartOrId)` and check the boolean. Verify in a fresh execution with `slide.charts.list().map((item) => item.describe())`. Insert charts after the final full-page SVG replacement, because replacement clears every page element.
+`slide.getCharts()` and `slide.getChart(id)` return live charts. Await
+`chart.setDataSource(values)` for data changes. Common setters update the live chart; for a complete
+replacement, use `chart.toBuilder().build()` and `await chart.update(info)`. Remove it with
+`await chart.remove()` and check the boolean. Verify in a fresh execution with
+`slide.getCharts().map((item) => ({ id: item.getId(), type: item.getType(), info: item.getInfo(), resource: item.getChartData() }))`.
+Insert charts after the final full-page SVG replacement, because replacement clears every page
+element.
 
 ## Transitions
 

--- a/test/skills-smoke.mjs
+++ b/test/skills-smoke.mjs
@@ -55,6 +55,49 @@ if (
 	throw new Error("bundled Slide skill is missing proactive generation guidance");
 }
 
+const chartContracts = [
+	{
+		name: "univer-board",
+		owner: "FBoard.newChart",
+		insert: "await board.insertChart(info)",
+		read: "board.getCharts()",
+		stale: ["board.charts", "FBoardCharts", "setData(values).commit()"],
+	},
+	{
+		name: "univer-doc",
+		owner: "FDocument.newChart",
+		insert: "await doc.insertChart(info)",
+		read: "doc.getCharts()",
+		stale: [
+			"doc.charts",
+			"FDocumentCharts",
+			"univerAPI.Enum.DocChartInsertAnchorKind",
+			"setData(values).commit()",
+		],
+	},
+	{
+		name: "univer-slide",
+		owner: "FSlide",
+		insert: "await slide.insertChart(info)",
+		read: "slide.getCharts()",
+		stale: ["slide.charts", "FSlideCharts", "setData(values).commit()"],
+	},
+];
+for (const contract of chartContracts) {
+	const skill = await ctx.skills.get(contract.name);
+	if (
+		skill === undefined ||
+		contract.stale.some((api) => skill.content.includes(api)) ||
+		!skill.content.includes(contract.owner) ||
+		!skill.content.includes(contract.insert) ||
+		!skill.content.includes(contract.read) ||
+		!skill.content.includes("chart.setDataSource(values)") ||
+		!skill.content.includes("await chart.remove()")
+	) {
+		throw new Error(`bundled Chart skill uses a stale Facade contract: ${contract.name}`);
+	}
+}
+
 for (const topic of ["univer-embed", "univer-cross-unit-formula"]) {
 	const skill = await ctx.skills.get(topic);
 	if (skill === undefined || !skill.content.includes("univer_execute")) {


### PR DESCRIPTION
## Summary
- update Board, Doc, and Slide Skills to use the direct owner chart APIs
- document the current `newChart() -> build() -> insertChart()` lifecycle and live-chart mutations
- add bundled Skill smoke coverage that rejects the removed chart collection contract

## Verification
- confirmed the APIs against `@univer-cli/api-reference@20260819-8595af2`
- `pnpm run build:lib`
- `pnpm run test:skills`
- `pnpm test`
- `git diff --check`