### PR TITLE
fix: run bundled Gateway/Worker as plain Node under Electron Desktop

### DIFF
--- a/src/host/adapters/unit-content/worker.ts
+++ b/src/host/adapters/unit-content/worker.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { delimiter } from 'node:path'
 import { PLUGIN_NODE_MODULES, UNIT_CONTENT_WORKER_ENTRY } from '../../artifacts/paths.ts'
+import { spawnEnvironment } from '../../processes/spawn-env.ts'
 import { UniverError } from '../../service/errors.ts'
 import type { JsonValue } from '../../service/types.ts'
 import { parseUnitContentWorkerEnvelope, type UnitContentWorkerRequest } from './protocol.ts'
@@ -79,5 +80,5 @@ function unitContentWorkerEnvironment(): NodeJS.ProcessEnv {
   // Let the worker resolve its native dependencies (@univerjs-pro/exchange-node-binding,
   // engine-formula-rust-binding, and platform sub-packages) from this plugin's node_modules.
   env.NODE_PATH = [PLUGIN_NODE_MODULES, process.env.NODE_PATH].filter((value): value is string => value !== undefined && value.length > 0).join(delimiter)
-  return env
+  return spawnEnvironment(env)
 }

--- a/src/host/processes/gateway/launcher.ts
+++ b/src/host/processes/gateway/launcher.ts
@@ -1,6 +1,7 @@
 import type { SpawnOptions } from 'node:child_process'
 import { delimiter } from 'node:path'
 import { GATEWAY_ENTRY, PLUGIN_NODE_MODULES, VIEWER_ROOT } from '../../artifacts/paths.ts'
+import { spawnEnvironment } from '../spawn-env.ts'
 
 /** Build the fixed executable and environment used for a bundled Gateway. */
 export function gatewayLaunch(port: number): { readonly command: string; readonly args: readonly string[]; readonly options: SpawnOptions } {
@@ -8,20 +9,21 @@ export function gatewayLaunch(port: number): { readonly command: string; readonl
     const value = process.env[key]
     return value === undefined ? [] : [[key, value] as const]
   })
+  const env: NodeJS.ProcessEnv = {
+    ...Object.fromEntries(inherited),
+    UNIVER_COLLAB_GATEWAY_PORT: String(port),
+    UNIVER_VIEW_ASSETS_ROOT: VIEWER_ROOT,
+    // Let the gateway and worker resolve their native dependencies
+    // (@univerjs-pro/exchange-node-binding, engine-formula-rust-binding, libsql) from this
+    // plugin's node_modules; the formula binding package resolves its own
+    // platform binary (no NAPI_RS_NATIVE_LIBRARY_PATH override needed).
+    NODE_PATH: [PLUGIN_NODE_MODULES, process.env.NODE_PATH].filter((value): value is string => value !== undefined && value.length > 0).join(delimiter),
+  }
   return {
     command: process.execPath,
     args: [GATEWAY_ENTRY],
     options: {
-      env: {
-        ...Object.fromEntries(inherited),
-        UNIVER_COLLAB_GATEWAY_PORT: String(port),
-        UNIVER_VIEW_ASSETS_ROOT: VIEWER_ROOT,
-        // Let the gateway and worker resolve their native dependencies
-        // (@univerjs-pro/exchange-node-binding, engine-formula-rust-binding, libsql) from this
-        // plugin's node_modules; the formula binding package resolves its own
-        // platform binary (no NAPI_RS_NATIVE_LIBRARY_PATH override needed).
-        NODE_PATH: [PLUGIN_NODE_MODULES, process.env.NODE_PATH].filter((value): value is string => value !== undefined && value.length > 0).join(delimiter),
-      },
+      env: spawnEnvironment(env),
       stdio: ['ignore', 'ignore', 'pipe'],
       windowsHide: true,
     },

--- a/src/host/processes/spawn-env.ts
+++ b/src/host/processes/spawn-env.ts
@@ -1,0 +1,14 @@
+/**
+ * Extra environment entries for spawning one bundled Node entry script
+ * (Gateway, Unit Content Worker) through `process.execPath`.
+ *
+ * When the plugin is hosted inside an Electron shell such as DSH Desktop,
+ * `process.execPath` is the Electron executable, not a Node binary. The spawned
+ * entries are plain Node scripts, so the child must opt into plain-Node mode via
+ * ELECTRON_RUN_AS_NODE=1; otherwise Electron boots as a GUI app and the child
+ * exits with code 0 before executing the script. A plain-Node host needs no
+ * such flag, so nothing is added there.
+ */
+export function spawnEnvironment(base: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return process.versions.electron === undefined ? base : { ...base, ELECTRON_RUN_AS_NODE: '1' }
+}

--- a/test/host-smoke.mjs
+++ b/test/host-smoke.mjs
@@ -1,7 +1,7 @@
 // Host browser-protocol smoke: real node:http server over the generated router,
 // with a deterministic service double. No global CLI or existing demo file.
 import { createServer } from 'node:http'
-import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Context } from '@deepseek-ai/cordis'
@@ -17,8 +17,12 @@ if (defaultConfig.gatewayPort !== 9080) throw new Error(`default Gateway port mu
 if (defaultConfig.screenshotMaxPages !== 30 || defaultConfig.screenshotMaxPixels !== 16_777_216) {
   throw new Error(`default screenshot limits drifted: ${JSON.stringify(defaultConfig)}`)
 }
-if (!defaultConfig.resourceCacheRoot.endsWith('/cache/dsh-univer-office/resources')) {
+if (!defaultConfig.resourceCacheRoot.endsWith(join('cache', 'dsh-univer-office', 'resources'))) {
   throw new Error(`default resource cache root drifted: ${defaultConfig.resourceCacheRoot}`)
+}
+const hostBundle = await readFile(new URL('../lib/index.js', import.meta.url), 'utf8')
+if (!hostBundle.includes('ELECTRON_RUN_AS_NODE')) {
+  throw new Error('Host bundle must set ELECTRON_RUN_AS_NODE so bundled Gateway/Worker entry scripts run as plain Node inside an Electron Desktop host')
 }
 try {
   resolveConfig({ gatewayPort: 0 })


### PR DESCRIPTION
When the plugin is hosted by DSH Desktop (Electron), process.execPath is the Electron executable, so spawning the bundled Gateway and Unit Content Worker without ELECTRON_RUN_AS_NODE=1 boots Electron as a GUI app and the child exits with code 0 before the Node script runs. Add a shared spawnEnvironment() helper that sets ELECTRON_RUN_AS_NODE=1 only when the host is Electron, and route both child environments through it. Add a host-smoke regression asserting the built bundle carries the flag.
Fixes #19 
Fixes #20 