### PR TITLE
docs: sync Chinese README intro with English

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,9 @@
 
 # DSH × Univer Office
 
-> 让 DeepSeek Harness 直接创建、编辑、检查和交付表格、文档、幻灯片、多维表格与画布。
+> 为 DeepSeek Harness 打造一个真正的办公环境。
+>
+> Univer Office 插件将电子表格、文档、幻灯片、画布、多维表格等汇聚到同一个运行时——数据互联、修改经过校验、变更按版本管理，并以隔离工作树支持多 Agent 协作。
 
 [English](README.md) · 简体中文
 


### PR DESCRIPTION
## Summary

The English README intro was enriched in #23 to a two-line tagline (one-line slogan + one-line capability description), but README.zh-CN.md still carried the old single-sentence intro. This PR mirrors the new English structure and wording in Chinese:

> 为 DeepSeek Harness 打造一个真正的办公环境。
>
> Univer Office 插件将电子表格、文档、幻灯片、画布、多维表格等汇聚到同一个运行时——数据互联、修改经过校验、变更按版本管理，并以隔离工作树支持多 Agent 协作。

Terminology follows the established Chinese copy: relational tables → 多维表格, validation → 校验, versioned changes → 变更按版本管理, isolated worktrees → 隔离工作树.

## Validation

- `git diff --check` passes.
- No other files touched; the pre-existing markdown table formatting notes in this file are unrelated to the edited blockquote.