### PR TITLE
feat: add anonymous product telemetry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,10 @@ jobs:
 
       - name: Build
         run: pnpm run build
+        env:
+          # Pin the live telemetry proxy into published builds only; local
+          # builds keep an empty endpoint and never send.
+          RELEASE_TELEMETRY_ENDPOINT: https://univer.ai/api/telemetry/cli
 
       - name: Test
         run: pnpm run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Choose the narrowest validation that proves the change:
 | Host, HTTP, or tools                                                                          | `pnpm run build:lib`             | `pnpm run test:host`                                            |
 | DSH Client                                                                                    | `pnpm run build:lib`             | `pnpm run test:client`                                          |
 | Bundled skills                                                                                | None                             | `pnpm run test:skills`                                          |
+| Product telemetry or lifecycle packaging                                                      | `pnpm run build:lib`             | `pnpm run test:telemetry`                                       |
 | Viewer UI                                                                                     | `pnpm run build:viewer`          | Add `test:integration` when behavior crosses a process boundary |
 | Gateway, Worker, persistence, worktree lifecycle, Render Machine, or a cross-process protocol | Build every affected application | `pnpm run test:integration`                                     |
 | Cross-layer or release change                                                                 | None separately                  | `pnpm test` (builds every target first)                         |
@@ -72,6 +73,7 @@ Run `pnpm run typecheck` for TypeScript changes and `git diff --check` before ev
 - Concurrent Gateway starts share one startup operation. Failure, early exit, and unload must clear ownership and allow retry. Stop only subprocesses started by this plugin, skip occupied ports, and verify the health endpoint identity.
 - Cancellation and teardown must reach quiescence: reject new notifications, abort or kill owned work, and await Worker, browser, and subprocess exit. One clear owner manages settlement and cleanup for each asynchronous operation.
 - `univer_screenshot` may return model-visible PNG attachments only when the current model supports image input and every output path is authorized. Claim visual verification only for images actually inspected; structural readback and Slide lint are not pixel-level proof.
+- Product telemetry sends only the allowlisted anonymous events defined in `docs/architecture.md`, from the Host process and the package lifecycle entry, and must never alter install, activation, command, or uninstall behavior. An empty endpoint, `DO_NOT_TRACK`, or `telemetry: false` must silence every entry point; never add analytics SDKs, client keys, retries, or payload fields outside the allowlist.
 
 ## 6. TypeScript and error contracts
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ The defaults are designed for local use: the service starts at port `9080`. If t
 | `resourceOperationTimeoutMs` | `120000` | Overall timeout for one resource-library tool operation |
 | `tools` | `true` | Enable agent editing capabilities |
 | `skills` | `true` | Enable bundled task guidance |
+| `telemetry` | `true` | Send anonymous product telemetry |
+
+## Telemetry
+
+Sends anonymous usage stats (never file contents or paths). Disable with `DO_NOT_TRACK=1` or `telemetry: false`.
 
 ## Uninstall
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -200,6 +200,11 @@ DSH 会自动选择这些工具，日常使用不需要手动调用。
 | `resourceOperationTimeoutMs` | `120000` | 一次资源库工具操作的总超时 |
 | `tools` | `true` | 启用 Agent 编辑能力 |
 | `skills` | `true` | 启用内置任务指引 |
+| `telemetry` | `true` | 发送匿名产品遥测 |
+
+## 遥测
+
+默认发送匿名使用统计（不含文件内容与路径）。设 `DO_NOT_TRACK=1` 或配置 `telemetry: false` 关闭。
 
 ## 卸载
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,8 @@
 - `processes/gateway` 负责插件内置 Gateway 进程和 Viewer 资源；
 - `workers/unit-content` 是一次性 Unit Content Worker 的子进程入口；
 - `client` 负责 DSH 浏览器端的预览、实时 worktree 窗口和用户审阅界面；
-- `shared/wire` 只存放 Host 与 Client 共享的纯 JSON 数据类型。
+- `shared/wire` 只存放 Host 与 Client 共享的纯 JSON 数据类型；
+- `telemetry` 提供 best-effort 的匿名产品遥测，只在 Host 与包 lifecycle 入口发送，任何失败都不影响安装、启动与卸载。
 
 用户只安装本插件即可使用全部功能。全局 `univer` CLI 不属于运行依赖；Unit 的导入、检查、执行和导出由插件内置的一次性 Unit Content Worker 完成。
 
@@ -128,6 +129,9 @@ src/
         resources.ts
     skills/
       plugin.ts                      # bundled lazy Skill Provider
+    telemetry/
+      product-telemetry.ts           # 匿名产品遥测：state、去重与白名单发送
+      entry.ts                       # 打包为 lib/telemetry-entry.js 的 lifecycle 发送入口
     adapters/
       gateway/
         client.ts
@@ -197,6 +201,7 @@ test/
   client-smoke.mjs
   integration-smoke.mjs
   skills-smoke.mjs
+  telemetry-smoke.mjs
 scripts/
   build.mjs
 skills/
@@ -352,7 +357,7 @@ Client 必须满足：
 
 ## 12. 构建与发布
 
-`src` 包含插件发布的所有 application 源码；Viewer application、machine render page、render preset 和 IMPORTRANGE plugin 源码从 `univer-cli` 复制到本仓库后直接维护。`pnpm run build` 生成 Host/Client bundle、Unit Content Worker、Gateway、machine render page 和 Viewer；`lib` 与 `artifacts` 都被 gitignore，并在打包前重新生成。Host 构建为 Node ESM，Client 构建为 DSH ModuleLoader 可加载的浏览器 bundle，Gateway 构建为 Node CJS 子进程，Worker 构建为 Node ESM 子进程，machine render page 与 Viewer 构建为 Vite 静态资产。
+`src` 包含插件发布的所有 application 源码；Viewer application、machine render page、render preset 和 IMPORTRANGE plugin 源码从 `univer-cli` 复制到本仓库后直接维护。`pnpm run build` 生成 Host/Client bundle、Unit Content Worker、Gateway、machine render page 和 Viewer；`lib` 与 `artifacts` 都被 gitignore，并在打包前重新生成。Host 构建为 Node ESM，Client 构建为 DSH ModuleLoader 可加载的浏览器 bundle，Gateway 构建为 Node CJS 子进程，Worker 构建为 Node ESM 子进程，machine render page 与 Viewer 构建为 Vite 静态资产。lib 构建同时生成 `lib/telemetry-entry.js`（lifecycle hook 发送入口）与 `lib/build-info.json`（包版本、构建 commit 与遥测 endpoint）。
 
 发布包包含运行所需的 Gateway、Viewer、Unit Content Worker、Office 转换器、平台依赖、Univer license 与 bundled Skills。Gateway、Worker、Viewer 和 Host 直接使用 manifest 中精确版本的 Univer SDK/API Reference packages；JavaScript SDK 被 bundle，平台原生 package 由包管理器为目标机器安装。发布时只打包从当前源码生成的运行产物。
 
@@ -384,7 +389,18 @@ Client 必须满足：
 - 不在当前阶段仅为目录整齐拆成多个 npm 包；
 - 不让模型自行决定 merge 或 discard；显式用户请求仍必须经过 DSH 工具审批。
 
-## 15. 变更规则
+## 15. 产品遥测
+
+产品遥测是 best-effort 的匿名安装与活跃统计，只用于看趋势，不用于精确计量。遥测绝不影响安装、插件启动或卸载：所有失败静默吞掉，发送有 5 秒超时，无重试、无队列、无锁。
+
+- 事件共四个，统一经 `lib/build-info.json` 中固定的 Univer 代理 endpoint 上报（版本与 commit 也取自该文件），客户端不持有任何分析平台凭证。release workflow 通过 `RELEASE_TELEMETRY_ENDPOINT` 把线上代理地址注入发布构建；本地与开发构建保持为空，即遥测整体静默（`telemetry: false` 的 disabled 标记写入除外，见下）。运行时显式设置 `UNIVER_TELEMETRY_ENDPOINT`（含空值）优先于构建固定值，用作测试重定向与应急开关。服务端 allowlist 必须先于带 endpoint 的构建部署，否则事件会被整包拒绝且因 at-most-once 永久丢失；
+- `dsh_plugin_postinstall`（包 postinstall，每安装身份一次）、`dsh_plugin_activated`（Host 激活，每安装身份一次）、`dsh_plugin_daily_active`（Host 激活时检查，每安装身份每本地日一次）、`dsh_plugin_uninstall_hook`（包 uninstall，不去重，因为 state 跨重装存活，一次性标记会掩盖后续卸载）；
+- payload 只允许 `distinctId`（随机 UUID）、事件名与白名单属性（package name/version、build commit、platform、arch、Node major version、event source、state schema version），禁止路径、workspace、session、文件内容与环境变量。服务端代理对未知键整包拒绝；
+- 去重只在本机 state（`$DSH_HOME/telemetry/dsh-univer-office/state.json`，沿用 `config.ts` 的 `DSH_HOME` 约定）中做，先落盘标记再发送（at-most-once：崩溃宁可丢事件不重发，标记写失败时同样放弃发送）；并发启动的毫秒级竞态接受偶发双发；
+- `telemetry: false` 配置由 Host 同步写入 state 的 `disabled` 标记，使拿不到 Cordis 配置的 lifecycle hook 发送同样停用，这也是空 endpoint 下唯一会创建 state 的路径；`DO_NOT_TRACK` 非空在所有入口直接短路；
+- 发送只发生在 Host 进程（fire-and-forget，不注册资源、不阻塞激活与卸载）与 `scripts/telemetry-entry.mjs` 启动的 detached 子进程中；Client、Viewer、Gateway 与 Worker 不发送遥测。
+
+## 16. 变更规则
 
 后续实现若改变以下任一事项，必须先更新本文并重新评审：
 
@@ -394,4 +410,5 @@ Client 必须满足：
 - worktree 用户审阅权归属；
 - 工具能力与 bundled Skills 的对应关系；
 - 源码构建、Viewer 与许可证策略；
-- 单包与多包的发布决策。
+- 单包与多包的发布决策；
+- 遥测事件集合、payload 白名单、去重语义或上报通道。

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "skills",
     "artifacts",
     "scripts/copy-gateway-dependencies.mjs",
+    "scripts/telemetry-entry.mjs",
     "README.md",
     "README.zh-CN.md",
     "cordis.patch.yml"
@@ -58,6 +59,8 @@
   },
   "scripts": {
     "prepare": "simple-git-hooks",
+    "postinstall": "node scripts/telemetry-entry.mjs postinstall",
+    "uninstall": "node scripts/telemetry-entry.mjs uninstall",
     "build": "pnpm run build:lib && pnpm run build:worker && pnpm run build:gateway && pnpm run build:render && pnpm run build:viewer",
     "build:lib": "node scripts/build.mjs lib",
     "build:worker": "node scripts/build.mjs worker",
@@ -74,7 +77,8 @@
     "test:host": "node test/host-smoke.mjs",
     "test:client": "node test/client-smoke.mjs combined && node test/client-smoke.mjs split",
     "test:skills": "node test/skills-smoke.mjs",
-    "test": "pnpm run build && pnpm run test:host && pnpm run test:integration && pnpm run test:client && pnpm run test:skills",
+    "test:telemetry": "node test/telemetry-smoke.mjs",
+    "test": "pnpm run build && pnpm run test:host && pnpm run test:integration && pnpm run test:client && pnpm run test:skills && pnpm run test:telemetry",
     "verify:public-dependencies": "node scripts/verify-public-runtime-dependencies.mjs",
     "prepublishOnly": "pnpm run build && pnpm run test"
   },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -9,6 +9,7 @@
 //   pnpm run build:viewer  → artifacts/viewer/
 //   pnpm run build         → all five applications
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { execFileSync } from 'node:child_process'
 import { builtinModules, createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import react from '@vitejs/plugin-react'
@@ -79,7 +80,35 @@ if (target === 'all' || target === 'lib') {
   const clientCode = client.outputFiles[0]?.text
   if (clientCode === undefined) throw new Error('client build produced no JavaScript')
   await writeFile('lib/client.js', `window.__ModuleLoader__.load({\n  id: "dsh-univer-office",\n  factory: (require) => {\n    var module = { exports: {} };\n    var exports = module.exports;\n${indent(clientCode, 4)}\n    return module.exports;\n  }\n});\n`)
-  console.log('built lib/index.js + lib/client.js')
+
+  // Product telemetry entry for package lifecycle hooks (postinstall/uninstall).
+  await build({
+    entryPoints: ['src/host/telemetry/entry.ts'],
+    outfile: 'lib/telemetry-entry.js',
+    bundle: true,
+    platform: 'node',
+    target: 'node22',
+    format: 'esm',
+    legalComments: 'none',
+    sourcemap: false,
+  })
+
+  // Telemetry endpoint: only the release workflow pins the live proxy address
+  // (RELEASE_TELEMETRY_ENDPOINT); local builds stay fully inert because an
+  // empty endpoint disables every send, including the lifecycle hooks.
+  const telemetryEndpoint = process.env.RELEASE_TELEMETRY_ENDPOINT ?? ''
+  const manifest = JSON.parse(await readFile('package.json', 'utf8'))
+  let commit = ''
+  try {
+    commit = execFileSync('git', ['rev-parse', 'HEAD'], { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+  } catch {
+    // Building outside a git checkout: telemetry payloads simply omit the commit.
+  }
+  await writeFile(
+    'lib/build-info.json',
+    `${JSON.stringify({ commit, telemetryEndpoint, version: manifest.version }, null, 2)}\n`
+  )
+  console.log('built lib/index.js + lib/client.js + lib/telemetry-entry.js')
 }
 
 if (target === 'all' || target === 'worker') {

--- a/scripts/telemetry-entry.mjs
+++ b/scripts/telemetry-entry.mjs
@@ -1,0 +1,28 @@
+// Package lifecycle entry (package.json "postinstall" / "uninstall"). It must
+// never fail or slow install and removal: if the bundled telemetry entry is
+// missing (fresh checkout before a build, scripts disabled) it exits silently,
+// and otherwise the send runs in a detached child process.
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const command = process.argv[2]
+const eventByCommand = {
+  postinstall: 'dsh_plugin_postinstall',
+  uninstall: 'dsh_plugin_uninstall_hook'
+}
+const event = command === undefined ? undefined : eventByCommand[command]
+const entry = join(
+  resolve(dirname(fileURLToPath(import.meta.url)), '..'),
+  'lib',
+  'telemetry-entry.js'
+)
+
+if (event !== undefined && existsSync(entry)) {
+  spawn(process.execPath, [entry, 'capture', event], {
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true
+  }).unref()
+}

--- a/src/host/config.ts
+++ b/src/host/config.ts
@@ -1,6 +1,6 @@
-import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
 import z from '@deepseek-ai/schemastery'
+import { resolveDshHome } from './dsh-home.ts'
 
 /** Configuration shared by the Univer service provider and its consumers. */
 export interface Config {
@@ -38,6 +38,8 @@ export interface Config {
   tools?: boolean
   /** Register version-matched bundled Univer skills. */
   skills?: boolean
+  /** Send anonymous product telemetry; `DO_NOT_TRACK` also turns it off. */
+  telemetry?: boolean
 }
 
 /** Fully resolved configuration used by the implementation. */
@@ -59,6 +61,7 @@ export interface ResolvedConfig {
   readonly unitCacheTtlMs: number
   readonly tools: boolean
   readonly skills: boolean
+  readonly telemetry: boolean
 }
 
 /** Cordis configuration schema. */
@@ -80,6 +83,7 @@ export const Config: z<Config> = z.object({
   unitCacheTtlMs: z.natural().default(5_000),
   tools: z.boolean().default(true),
   skills: z.boolean().default(true),
+  telemetry: z.boolean().default(true)
 })
 
 /** Apply defaults and reject configuration that cannot run. */
@@ -102,8 +106,13 @@ export function resolveConfig(config: Config = {}): ResolvedConfig {
     unitCacheTtlMs: config.unitCacheTtlMs ?? 5_000,
     tools: config.tools ?? true,
     skills: config.skills ?? true,
+    telemetry: config.telemetry ?? true
   }
-  if (!Number.isInteger(resolved.gatewayPort) || resolved.gatewayPort < 1 || resolved.gatewayPort > 65_535) {
+  if (
+    !Number.isInteger(resolved.gatewayPort) ||
+    resolved.gatewayPort < 1 ||
+    resolved.gatewayPort > 65_535
+  ) {
     throw new Error('univer: gatewayPort must be an integer between 1 and 65535')
   }
   for (const [name, value] of Object.entries({
@@ -118,9 +127,10 @@ export function resolveConfig(config: Config = {}): ResolvedConfig {
     resourceOperationTimeoutMs: resolved.resourceOperationTimeoutMs,
     unitContentCommitTimeoutMs: resolved.unitContentCommitTimeoutMs,
     stateCacheTtlMs: resolved.stateCacheTtlMs,
-    unitCacheTtlMs: resolved.unitCacheTtlMs,
+    unitCacheTtlMs: resolved.unitCacheTtlMs
   })) {
-    if (!Number.isSafeInteger(value) || value < 1) throw new Error(`univer: ${name} must be a positive integer`)
+    if (!Number.isSafeInteger(value) || value < 1)
+      throw new Error(`univer: ${name} must be a positive integer`)
   }
   return resolved
 }
@@ -132,13 +142,5 @@ function resolveResourceCacheRoot(configured: string | undefined): string {
     }
     return resolve(configured)
   }
-  const configuredHome = process.env.DSH_HOME?.trim()
-  const dshHome = configuredHome === undefined || configuredHome.length === 0
-    ? join(homedir(), '.dsh')
-    : configuredHome === '~'
-      ? homedir()
-      : configuredHome.startsWith('~/')
-        ? join(homedir(), configuredHome.slice(2))
-        : resolve(configuredHome)
-  return join(dshHome, 'cache', 'dsh-univer-office', 'resources')
+  return join(resolveDshHome(), 'cache', 'dsh-univer-office', 'resources')
 }

--- a/src/host/dsh-home.ts
+++ b/src/host/dsh-home.ts
@@ -1,0 +1,19 @@
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+/**
+ * Single source of the `DSH_HOME` convention shared by config resolution and
+ * telemetry state: unset falls back to `~/.dsh`, `~` and `~/` expand against
+ * the home directory, and anything else resolves against the current working
+ * directory.
+ */
+export function resolveDshHome(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = homedir()
+): string {
+  const configured = env.DSH_HOME?.trim()
+  if (configured === undefined || configured.length === 0) return join(homeDir, '.dsh')
+  if (configured === '~') return homeDir
+  if (configured.startsWith('~/')) return join(homeDir, configured.slice(2))
+  return resolve(configured)
+}

--- a/src/host/index.ts
+++ b/src/host/index.ts
@@ -3,6 +3,7 @@ import { resolveConfig } from './config.ts'
 import type { Config as UniverConfig } from './config.ts'
 import * as provider from './provider/plugin.ts'
 import * as skills from './skills/plugin.ts'
+import { runHostTelemetry } from './telemetry/product-telemetry.ts'
 import * as tools from './tools/plugin.ts'
 import * as webServer from './webServer/plugin.ts'
 
@@ -11,6 +12,17 @@ export type { UniverConfig }
 export { GatewayUniverService } from './provider/gateway-univer-service.ts'
 export { UniverService } from './service/univer-service.ts'
 export { createUniverRouter } from './webServer/router.ts'
+export {
+  captureTelemetry,
+  parseTelemetryState,
+  resolveTelemetryStatePath,
+  runHostTelemetry,
+} from './telemetry/product-telemetry.ts'
+export type {
+  TelemetryCapture,
+  TelemetryState,
+  TelemetryStateIo,
+} from './telemetry/product-telemetry.ts'
 export * from '../shared/wire/actions.ts'
 export * from '../shared/wire/state.ts'
 export * from '../shared/wire/status.ts'
@@ -20,6 +32,9 @@ export const name = 'dsh-univer-office'
 /** Compose the Univer Provider and its Web/Tools Consumers. */
 export function apply(ctx: Context, config: UniverConfig = {}): void {
   const resolved = resolveConfig(config)
+  // Fire-and-forget: bounded by an internal timeout and never throws, so it
+  // can neither delay activation nor leave work for unload to settle.
+  void runHostTelemetry({ telemetryEnabled: resolved.telemetry })
   ctx.plugin(provider, resolved)
   ctx.plugin(webServer)
   if (resolved.tools) ctx.plugin(tools, resolved)

--- a/src/host/telemetry/entry.ts
+++ b/src/host/telemetry/entry.ts
@@ -1,0 +1,40 @@
+// CLI entry for package lifecycle hooks. Bundled to lib/telemetry-entry.js and
+// launched detached by scripts/telemetry-entry.mjs so that package install and
+// removal never wait on telemetry. Unknown arguments and every failure are
+// silently ignored: telemetry must never fail install or uninstall.
+import {
+  captureTelemetry,
+  readBundledBuildInfo,
+  telemetryEndpointFor
+} from './product-telemetry.ts'
+import type { TelemetryEventName, TelemetryEventSource } from './product-telemetry.ts'
+
+function isTelemetryEventName(value: string | undefined): value is TelemetryEventName {
+  return (
+    value === 'dsh_plugin_postinstall' ||
+    value === 'dsh_plugin_activated' ||
+    value === 'dsh_plugin_daily_active' ||
+    value === 'dsh_plugin_uninstall_hook'
+  )
+}
+
+function sourceFor(event: TelemetryEventName): TelemetryEventSource {
+  if (event === 'dsh_plugin_postinstall') return 'postinstall'
+  if (event === 'dsh_plugin_uninstall_hook') return 'uninstall-hook'
+  return 'host-activate'
+}
+
+const event = process.argv[3]
+if (process.argv[2] === 'capture' && isTelemetryEventName(event)) {
+  try {
+    const buildInfo = readBundledBuildInfo()
+    await captureTelemetry({
+      buildInfo,
+      endpoint: telemetryEndpointFor({ buildInfo }),
+      event,
+      source: sourceFor(event)
+    })
+  } catch {
+    // Telemetry must never affect install or uninstall.
+  }
+}

--- a/src/host/telemetry/product-telemetry.ts
+++ b/src/host/telemetry/product-telemetry.ts
@@ -1,0 +1,405 @@
+// Best-effort product telemetry. Four allowlisted events travel through the
+// Univer-owned proxy (https://univer.ai/api/telemetry/cli); the proxy holds the
+// only analytics credentials, and this client never carries a key. Telemetry
+// must never change install, startup, or uninstall behavior: every failure is
+// swallowed, sends are bounded by a short timeout, and there is no retry.
+//
+// Deduplication is local-only, recorded in one state file before the first
+// send attempt (at-most-once: a crash between write and send loses the event
+// but never duplicates it). Concurrent host starts may race on that file and
+// double-send once; this is accepted because the signal is read as a trend.
+import { randomUUID } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { resolveDshHome } from '../dsh-home.ts'
+
+export const TELEMETRY_STATE_VERSION = 1
+export const TELEMETRY_TIMEOUT_MS = 5_000
+
+export type TelemetryEventName =
+  | 'dsh_plugin_postinstall'
+  | 'dsh_plugin_activated'
+  | 'dsh_plugin_daily_active'
+  | 'dsh_plugin_uninstall_hook'
+
+export type TelemetryEventSource = 'postinstall' | 'uninstall-hook' | 'host-activate'
+
+/** Version and commit recorded at build time by scripts/build.mjs. */
+export interface TelemetryBuildInfo {
+  readonly telemetryEndpoint?: string
+  readonly version?: string
+  readonly commit?: string
+}
+
+export interface TelemetryState {
+  readonly anonymousInstallId: string
+  /** Mirrored from the `telemetry` config so hook-fired sends honor it too. */
+  readonly disabled?: boolean
+  readonly postinstallAttemptedAt?: string
+  readonly activatedAttemptedAt?: string
+  readonly dailyActiveSentDate?: string
+  readonly version: typeof TELEMETRY_STATE_VERSION
+}
+
+export interface TelemetryStateIo {
+  readonly readFile?: typeof readFile
+  readonly writeFile?: typeof writeFile
+  readonly rename?: typeof rename
+  readonly mkdir?: typeof mkdir
+}
+
+export interface TelemetryCapture {
+  readonly distinctId: string
+  readonly event: TelemetryEventName
+  readonly properties: Record<string, string | number>
+}
+
+export type TelemetryTransport = (input: {
+  readonly body: TelemetryCapture
+  readonly endpoint: string
+}) => Promise<void>
+
+export interface CaptureTelemetryInput {
+  readonly event: TelemetryEventName
+  readonly source: TelemetryEventSource
+  readonly buildInfo: TelemetryBuildInfo
+  readonly endpoint: string
+  readonly env?: NodeJS.ProcessEnv
+  readonly now?: Date
+  readonly randomId?: () => string
+  readonly stateIo?: TelemetryStateIo
+  readonly statePath?: string
+  readonly transport?: TelemetryTransport
+}
+
+export interface CaptureTelemetryResult {
+  readonly reason?:
+    | 'already-attempted'
+    | 'already-sent-today'
+    | 'capture-failed'
+    | 'disabled'
+    | 'do-not-track'
+    | 'missing-endpoint'
+    | 'state-unavailable'
+  readonly status: 'captured' | 'skipped'
+}
+
+export interface HostTelemetryInput {
+  /** Mirrored into the state file so hook-fired sends honor the config too. */
+  readonly telemetryEnabled: boolean
+  readonly buildInfo?: TelemetryBuildInfo
+  readonly env?: NodeJS.ProcessEnv
+  readonly now?: Date
+  readonly randomId?: () => string
+  readonly stateIo?: TelemetryStateIo
+  readonly statePath?: string
+  readonly transport?: TelemetryTransport
+}
+
+export function resolveTelemetryStatePath(
+  input: {
+    readonly env?: NodeJS.ProcessEnv
+    readonly homeDir?: string
+  } = {}
+): string {
+  const env = input.env ?? process.env
+  return resolve(resolveDshHome(env, input.homeDir), 'telemetry', 'dsh-univer-office', 'state.json')
+}
+
+/**
+ * Resolution order: an explicitly set `UNIVER_TELEMETRY_ENDPOINT` (even empty,
+ * which disables telemetry) wins over the value pinned into the build by the
+ * release workflow, so tests and incident response can always redirect or cut
+ * the endpoint. An empty result disables telemetry entirely.
+ */
+export function telemetryEndpointFor(input: {
+  readonly buildInfo: TelemetryBuildInfo
+  readonly env?: NodeJS.ProcessEnv
+}): string {
+  const env = input.env ?? process.env
+  const override = env.UNIVER_TELEMETRY_ENDPOINT
+  if (override !== undefined) {
+    const trimmed = override.trim()
+    return trimmed.length === 0 ? '' : trimmed
+  }
+  const fromBuildInfo = input.buildInfo.telemetryEndpoint?.trim()
+  return fromBuildInfo === undefined || fromBuildInfo.length === 0 ? '' : fromBuildInfo
+}
+
+/**
+ * Reads the build-info file generated next to the bundled entry by
+ * scripts/build.mjs. Absent or malformed file (dev checkout without a build)
+ * yields an empty info, which keeps telemetry inert via the empty endpoint.
+ */
+export function readBundledBuildInfo(): TelemetryBuildInfo {
+  try {
+    const value: unknown = JSON.parse(
+      readFileSync(new URL('build-info.json', import.meta.url), 'utf8')
+    )
+    if (!isRecord(value)) return {}
+    return {
+      ...(typeof value.telemetryEndpoint === 'string' && value.telemetryEndpoint.length > 0
+        ? { telemetryEndpoint: value.telemetryEndpoint }
+        : {}),
+      ...(typeof value.commit === 'string' ? { commit: value.commit } : {}),
+      ...(typeof value.version === 'string' ? { version: value.version } : {})
+    }
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Runs the host-side telemetry pass at plugin activation: syncs the disabled
+ * flag, then reports activation and the daily session. Never throws and
+ * registers nothing, so plugin unload has no telemetry resources to settle.
+ */
+export async function runHostTelemetry(input: HostTelemetryInput): Promise<void> {
+  const env = input.env ?? process.env
+  if (isDoNotTrack(env)) return
+  try {
+    const buildInfo = input.buildInfo ?? readBundledBuildInfo()
+    const statePath = input.statePath ?? resolveTelemetryStatePath({ env })
+    const enabled = await syncTelemetryDisabled({
+      statePath,
+      telemetryEnabled: input.telemetryEnabled,
+      ...(input.stateIo === undefined ? {} : { stateIo: input.stateIo })
+    })
+    if (!enabled) return
+    const endpoint = telemetryEndpointFor({ buildInfo, env })
+    if (endpoint.length === 0) return
+    const base = {
+      buildInfo,
+      endpoint,
+      env,
+      ...(input.now === undefined ? {} : { now: input.now }),
+      ...(input.randomId === undefined ? {} : { randomId: input.randomId }),
+      ...(input.stateIo === undefined ? {} : { stateIo: input.stateIo }),
+      statePath,
+      ...(input.transport === undefined ? {} : { transport: input.transport })
+    }
+    await captureTelemetry({ ...base, event: 'dsh_plugin_activated', source: 'host-activate' })
+    await captureTelemetry({ ...base, event: 'dsh_plugin_daily_active', source: 'host-activate' })
+  } catch {
+    // Telemetry must never affect plugin activation.
+  }
+}
+
+/** Returns false when telemetry must stay off for hook sends as well. */
+async function syncTelemetryDisabled(input: {
+  readonly statePath: string
+  readonly stateIo?: TelemetryStateIo
+  readonly telemetryEnabled: boolean
+}): Promise<boolean> {
+  const state = await readOrCreateTelemetryState({
+    path: input.statePath,
+    ...(input.stateIo === undefined ? {} : { stateIo: input.stateIo })
+  })
+  if (!input.telemetryEnabled) {
+    if (state.disabled !== true) {
+      await writeTelemetryState({
+        path: input.statePath,
+        state: { ...state, disabled: true, version: TELEMETRY_STATE_VERSION },
+        ...(input.stateIo === undefined ? {} : { stateIo: input.stateIo })
+      })
+    }
+    return false
+  }
+  if (state.disabled === true) {
+    // The config re-enabled telemetry: clear the flag so hook sends resume.
+    const { disabled: _disabled, ...withoutDisabled } = state
+    await writeTelemetryState({
+      path: input.statePath,
+      state: { ...withoutDisabled, version: TELEMETRY_STATE_VERSION },
+      ...(input.stateIo === undefined ? {} : { stateIo: input.stateIo })
+    })
+  }
+  return true
+}
+
+export async function captureTelemetry(
+  input: CaptureTelemetryInput
+): Promise<CaptureTelemetryResult> {
+  const env = input.env ?? process.env
+  if (isDoNotTrack(env)) return { reason: 'do-not-track', status: 'skipped' }
+  if (input.endpoint.length === 0) return { reason: 'missing-endpoint', status: 'skipped' }
+
+  const now = input.now ?? new Date()
+  const statePath = input.statePath ?? resolveTelemetryStatePath({ env })
+  const state = await readOrCreateTelemetryState({
+    path: statePath,
+    ...(input.randomId === undefined ? {} : { randomId: input.randomId }),
+    ...(input.stateIo === undefined ? {} : { stateIo: input.stateIo })
+  })
+  if (state.disabled === true) return { reason: 'disabled', status: 'skipped' }
+
+  const next = markTelemetryEvent({ event: input.event, now, state })
+  if (next === undefined) return { reason: alreadyReason(input.event), status: 'skipped' }
+  const persisted = await writeTelemetryState({
+    path: statePath,
+    state: next,
+    ...(input.stateIo === undefined ? {} : { stateIo: input.stateIo })
+  })
+  // Fail closed: an unpersisted mark would let later starts send duplicates,
+  // so the send is dropped instead (losing one event beats double counting).
+  if (!persisted) return { reason: 'state-unavailable', status: 'skipped' }
+
+  const nodeMajor = readNodeMajorVersion(process.versions.node)
+  const capture: TelemetryCapture = {
+    distinctId: next.anonymousInstallId,
+    event: input.event,
+    properties: {
+      arch: process.arch,
+      build_commit: input.buildInfo.commit ?? '',
+      event_source: input.source,
+      // The proxy rejects unknown or non-scalar values wholesale, so an
+      // unavailable version is omitted instead of sent as a placeholder.
+      ...(nodeMajor === undefined ? {} : { node_major_version: nodeMajor }),
+      package_name: 'dsh-univer-office',
+      package_version: input.buildInfo.version ?? '',
+      platform: process.platform,
+      telemetry_state_version: TELEMETRY_STATE_VERSION
+    }
+  }
+  try {
+    const send = input.transport ?? fetchTelemetryTransport
+    await send({ body: capture, endpoint: input.endpoint })
+    return { status: 'captured' }
+  } catch {
+    return { reason: 'capture-failed', status: 'skipped' }
+  }
+}
+
+export const fetchTelemetryTransport: TelemetryTransport = async ({ body, endpoint }) => {
+  const response = await fetch(endpoint, {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+    signal: AbortSignal.timeout(TELEMETRY_TIMEOUT_MS)
+  })
+  if (!response.ok) throw new Error(`telemetry proxy responded with status ${response.status}`)
+}
+
+/**
+ * Applies the once-only (or daily) mark for an event, or returns undefined
+ * when the event was already attempted and must not be sent again. The
+ * uninstall hook is deliberately never deduplicated: state survives
+ * reinstall, so a once-mark would hide every uninstall after the first.
+ */
+function markTelemetryEvent(input: {
+  readonly event: TelemetryEventName
+  readonly now: Date
+  readonly state: TelemetryState
+}): TelemetryState | undefined {
+  const { event, now, state } = input
+  if (event === 'dsh_plugin_uninstall_hook') return state
+  if (event === 'dsh_plugin_daily_active') {
+    const date = localDate(now)
+    if (state.dailyActiveSentDate === date) return undefined
+    return { ...state, dailyActiveSentDate: date, version: TELEMETRY_STATE_VERSION }
+  }
+  if (event === 'dsh_plugin_postinstall' && state.postinstallAttemptedAt !== undefined)
+    return undefined
+  if (event === 'dsh_plugin_activated' && state.activatedAttemptedAt !== undefined) return undefined
+  return {
+    ...state,
+    [event === 'dsh_plugin_postinstall' ? 'postinstallAttemptedAt' : 'activatedAttemptedAt']:
+      now.toISOString(),
+    version: TELEMETRY_STATE_VERSION
+  }
+}
+
+function alreadyReason(event: TelemetryEventName): 'already-attempted' | 'already-sent-today' {
+  return event === 'dsh_plugin_daily_active' ? 'already-sent-today' : 'already-attempted'
+}
+
+export function parseTelemetryState(json: string): TelemetryState {
+  const value: unknown = JSON.parse(json)
+  if (!isRecord(value) || value.version !== TELEMETRY_STATE_VERSION) {
+    throw new Error('Invalid telemetry state version.')
+  }
+  if (typeof value.anonymousInstallId !== 'string' || value.anonymousInstallId.length === 0) {
+    throw new Error('Invalid telemetry anonymous install id.')
+  }
+  const activatedAttemptedAt = readTimestamp(value.activatedAttemptedAt)
+  const postinstallAttemptedAt = readTimestamp(value.postinstallAttemptedAt)
+  const dailyActiveSentDate =
+    typeof value.dailyActiveSentDate === 'string' && value.dailyActiveSentDate.length > 0
+      ? value.dailyActiveSentDate
+      : undefined
+  return {
+    anonymousInstallId: value.anonymousInstallId,
+    ...(activatedAttemptedAt === undefined ? {} : { activatedAttemptedAt }),
+    ...(value.disabled === true ? { disabled: true } : {}),
+    ...(postinstallAttemptedAt === undefined ? {} : { postinstallAttemptedAt }),
+    ...(dailyActiveSentDate === undefined ? {} : { dailyActiveSentDate }),
+    version: TELEMETRY_STATE_VERSION
+  }
+}
+
+export function serializeTelemetryState(state: TelemetryState): string {
+  return `${JSON.stringify(state, null, 2)}\n`
+}
+
+async function readOrCreateTelemetryState(input: {
+  readonly path: string
+  readonly randomId?: () => string
+  readonly stateIo?: TelemetryStateIo
+}): Promise<TelemetryState> {
+  const read = input.stateIo?.readFile ?? readFile
+  try {
+    return parseTelemetryState(await read(input.path, 'utf8'))
+  } catch {
+    // Missing or corrupt state starts a fresh anonymous identity; the old one,
+    // if any, is unrecoverable and a duplicate activation is acceptable.
+    return {
+      anonymousInstallId: input.randomId?.() ?? randomUUID(),
+      version: TELEMETRY_STATE_VERSION
+    }
+  }
+}
+
+async function writeTelemetryState(input: {
+  readonly path: string
+  readonly state: TelemetryState
+  readonly stateIo?: TelemetryStateIo
+}): Promise<boolean> {
+  const write = input.stateIo?.writeFile ?? writeFile
+  const move = input.stateIo?.rename ?? rename
+  const makeDir = input.stateIo?.mkdir ?? mkdir
+  const tempPath = `${input.path}.${process.pid}.${Date.now()}.tmp`
+  try {
+    await makeDir(dirname(input.path), { mode: 0o700, recursive: true })
+    await write(tempPath, serializeTelemetryState(input.state), { encoding: 'utf8', mode: 0o600 })
+    await move(tempPath, input.path)
+    return true
+  } catch {
+    // Telemetry state must never affect install or plugin activation.
+    return false
+  }
+}
+
+function isDoNotTrack(env: NodeJS.ProcessEnv): boolean {
+  const value = env.DO_NOT_TRACK?.trim()
+  return value !== undefined && value.length > 0
+}
+
+function localDate(now: Date): string {
+  const month = `${now.getMonth() + 1}`.padStart(2, '0')
+  const day = `${now.getDate()}`.padStart(2, '0')
+  return `${now.getFullYear()}-${month}-${day}`
+}
+
+function readTimestamp(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function readNodeMajorVersion(version: string): number | undefined {
+  const major = Number(version.split('.')[0])
+  return Number.isSafeInteger(major) && major > 0 ? major : undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/test/telemetry-smoke.mjs
+++ b/test/telemetry-smoke.mjs
@@ -1,0 +1,306 @@
+// Product telemetry smoke: the real lifecycle entry CLI and the real host
+// telemetry pass against a local proxy double, with temporary DSH_HOME state
+// and a dynamic port. Asserts final state-file content, wire payload shape,
+// once-only semantics, and that telemetry can never fail install or startup.
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as UniverPlugin from '../lib/index.js'
+
+const {
+  captureTelemetry,
+  parseTelemetryState,
+  resolveConfig,
+  resolveTelemetryStatePath,
+  runHostTelemetry
+} = UniverPlugin
+
+const manifest = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+if (manifest.files.includes('scripts/telemetry-entry.mjs') !== true) {
+  throw new Error('published package must ship scripts/telemetry-entry.mjs')
+}
+if (manifest.scripts.postinstall !== 'node scripts/telemetry-entry.mjs postinstall') {
+  throw new Error('postinstall must launch only the package-owned telemetry entry')
+}
+if (manifest.scripts.uninstall !== 'node scripts/telemetry-entry.mjs uninstall') {
+  throw new Error('uninstall must launch only the package-owned telemetry entry')
+}
+if (resolveConfig().telemetry !== true || resolveConfig({ telemetry: false }).telemetry !== false) {
+  throw new Error('telemetry config default must be true and accept an explicit false')
+}
+
+const buildInfo = JSON.parse(
+  await readFile(new URL('../lib/build-info.json', import.meta.url), 'utf8')
+)
+// Local builds pin an empty endpoint; the release workflow pins the live proxy.
+// Anything else in build-info means the pin drifted from the reviewed target.
+if (
+  buildInfo.telemetryEndpoint !== '' &&
+  buildInfo.telemetryEndpoint !== 'https://univer.ai/api/telemetry/cli'
+) {
+  throw new Error(`unexpected pinned telemetry endpoint: ${buildInfo.telemetryEndpoint}`)
+}
+if (buildInfo.version !== manifest.version) {
+  throw new Error(`build-info version must track package.json: ${buildInfo.version}`)
+}
+if (!existsSync(new URL('../lib/telemetry-entry.js', import.meta.url))) {
+  throw new Error('build must emit lib/telemetry-entry.js for lifecycle hooks')
+}
+
+const requests = []
+const server = createServer((request, response) => {
+  const chunks = []
+  request.on('data', (chunk) => chunks.push(chunk))
+  request.on('end', () => {
+    requests.push({ body: JSON.parse(Buffer.concat(chunks).toString('utf8')), url: request.url })
+    response.writeHead(204, { 'cache-control': 'no-store' })
+    response.end()
+  })
+})
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+const endpoint = `http://127.0.0.1:${server.address().port}/api/telemetry/cli`
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu
+const EXPECTED_PROPERTIES = [
+  'arch',
+  'build_commit',
+  'event_source',
+  'node_major_version',
+  'package_name',
+  'package_version',
+  'platform',
+  'telemetry_state_version'
+]
+const now = new Date()
+const today = `${now.getFullYear()}-${`${now.getMonth() + 1}`.padStart(2, '0')}-${`${now.getDate()}`.padStart(2, '0')}`
+
+const home = await mkdtemp(join(tmpdir(), 'dsh-univer-telemetry-smoke-'))
+// Asynchronous spawn: the proxy double lives in this process, so a synchronous
+// wait would block the event loop and starve the child's fetch.
+const entryPath = new URL('../lib/telemetry-entry.js', import.meta.url).pathname
+const runProcess = (file, args, env) =>
+  new Promise((resolve) => {
+    const child = spawn(process.execPath, [file, ...args], { env, stdio: 'ignore' })
+    child.on('close', (code) => resolve({ status: code }))
+  })
+try {
+  const entryEnvironment = { ...process.env, DSH_HOME: home, UNIVER_TELEMETRY_ENDPOINT: endpoint }
+
+  // The postinstall hook reports once per install identity.
+  const statePath = resolveTelemetryStatePath({ env: entryEnvironment })
+  const install = await runProcess(
+    entryPath,
+    ['capture', 'dsh_plugin_postinstall'],
+    entryEnvironment
+  )
+  if (install.status !== 0) throw new Error(`postinstall entry must exit 0: ${install.status}`)
+  if (requests.length !== 1)
+    throw new Error(`postinstall must send exactly one event: ${requests.length}`)
+  if (requests[0].body.event !== 'dsh_plugin_postinstall')
+    throw new Error('postinstall sent the wrong event')
+  if (requests[0].body.properties.event_source !== 'postinstall')
+    throw new Error('wrong event source')
+  assertPayloadShape(requests[0].body)
+  const state = parseTelemetryState(await readFile(statePath, 'utf8'))
+  if (state.postinstallAttemptedAt === undefined)
+    throw new Error('state must record the postinstall attempt')
+
+  await runProcess(entryPath, ['capture', 'dsh_plugin_postinstall'], entryEnvironment)
+  if (requests.length !== 1)
+    throw new Error('postinstall must not be sent twice for one install identity')
+
+  // The uninstall hook is deliberately never deduplicated.
+  await runProcess(entryPath, ['capture', 'dsh_plugin_uninstall_hook'], entryEnvironment)
+  await runProcess(entryPath, ['capture', 'dsh_plugin_uninstall_hook'], entryEnvironment)
+  if (requests.length !== 3)
+    throw new Error(`uninstall hook must not deduplicate: ${requests.length}`)
+  if (requests[2].body.properties.event_source !== 'uninstall-hook')
+    throw new Error('wrong event source')
+
+  // DO_NOT_TRACK suppresses everything, including state creation.
+  const trackedHome = `${home}-dnt`
+  await runProcess(entryPath, ['capture', 'dsh_plugin_postinstall'], {
+    ...entryEnvironment,
+    DSH_HOME: trackedHome,
+    DO_NOT_TRACK: '1'
+  })
+  if (requests.length !== 3) throw new Error('DO_NOT_TRACK must suppress sends')
+  if (existsSync(resolveTelemetryStatePath({ env: { DSH_HOME: trackedHome } }))) {
+    throw new Error('DO_NOT_TRACK must not create telemetry state')
+  }
+
+  // An explicitly empty endpoint override stays fully inert even when the
+  // build pins the live proxy (release CI builds and incident kill-switch).
+  const inertHome = `${home}-inert`
+  await runProcess(entryPath, ['capture', 'dsh_plugin_postinstall'], {
+    ...process.env,
+    DSH_HOME: inertHome,
+    UNIVER_TELEMETRY_ENDPOINT: ''
+  })
+  if (requests.length !== 3) throw new Error('empty endpoint override must suppress sends')
+  if (existsSync(resolveTelemetryStatePath({ env: { DSH_HOME: inertHome } }))) {
+    throw new Error('empty endpoint override must not create telemetry state')
+  }
+
+  // A disabled state file gates hook sends; host activation clears the flag.
+  const disabledHome = `${home}-disabled`
+  const disabledPath = resolveTelemetryStatePath({ env: { DSH_HOME: disabledHome } })
+  await mkdir(join(disabledPath, '..'), { recursive: true })
+  await writeFile(
+    disabledPath,
+    `${JSON.stringify({ anonymousInstallId: crypto.randomUUID(), disabled: true, version: 1 }, null, 2)}\n`
+  )
+  await runProcess(entryPath, ['capture', 'dsh_plugin_postinstall'], {
+    ...entryEnvironment,
+    DSH_HOME: disabledHome
+  })
+  if (requests.length !== 3) throw new Error('disabled state must suppress hook sends')
+
+  const reEnabled = []
+  await runHostTelemetry({
+    buildInfo: { telemetryEndpoint: endpoint, commit: 'c0ffee', version: '9.9.9' },
+    env: { ...process.env, DSH_HOME: disabledHome },
+    statePath: disabledPath,
+    transport: async ({ body }) => reEnabled.push(body),
+    telemetryEnabled: true
+  })
+  if (reEnabled.length !== 2)
+    throw new Error(`activation must clear disabled and send twice: ${reEnabled.length}`)
+  const cleared = parseTelemetryState(await readFile(disabledPath, 'utf8'))
+  if (cleared.disabled === true) throw new Error('host activation must clear the disabled flag')
+
+  // Host activation reports activated once and daily active once per day.
+  const hostHome = `${home}-host`
+  const hostStatePath = resolveTelemetryStatePath({ env: { DSH_HOME: hostHome } })
+  const sent = []
+  const transport = async ({ body }) => sent.push(body)
+  const hostBase = {
+    buildInfo: { telemetryEndpoint: endpoint, commit: 'c0ffee', version: '9.9.9' },
+    env: { ...process.env, DSH_HOME: hostHome },
+    statePath: hostStatePath,
+    transport
+  }
+  await runHostTelemetry({ ...hostBase, telemetryEnabled: true })
+  if (sent.map((body) => body.event).join(',') !== 'dsh_plugin_activated,dsh_plugin_daily_active') {
+    throw new Error(
+      `first activation must send activated then daily active: ${sent.map((body) => body.event).join(',')}`
+    )
+  }
+  assertPayloadShape(sent[0])
+  const hostState = parseTelemetryState(await readFile(hostStatePath, 'utf8'))
+  if (hostState.activatedAttemptedAt === undefined) throw new Error('state must record activation')
+  if (hostState.dailyActiveSentDate !== today)
+    throw new Error(`state must record today: ${hostState.dailyActiveSentDate}`)
+  await runHostTelemetry({ ...hostBase, telemetryEnabled: true })
+  if (sent.length !== 2) throw new Error(`same-day restart must not resend: ${sent.length}`)
+
+  // Disabling via config writes the flag before any hook can fire and sends nothing.
+  const offHome = `${home}-off`
+  await runHostTelemetry({
+    buildInfo: { telemetryEndpoint: endpoint, version: '9.9.9' },
+    env: { ...process.env, DSH_HOME: offHome },
+    statePath: resolveTelemetryStatePath({ env: { DSH_HOME: offHome } }),
+    transport,
+    telemetryEnabled: false
+  })
+  if (sent.length !== 2) throw new Error('disabled telemetry must not send')
+  const offState = parseTelemetryState(
+    await readFile(resolveTelemetryStatePath({ env: { DSH_HOME: offHome } }), 'utf8')
+  )
+  if (offState.disabled !== true) throw new Error('disabled config must persist the disabled flag')
+
+  // A failed state write must fail closed: no persisted mark, no send.
+  const blockedSent = []
+  const blocked = await captureTelemetry({
+    buildInfo: { telemetryEndpoint: endpoint, commit: 'c0ffee', version: '9.9.9' },
+    endpoint,
+    event: 'dsh_plugin_postinstall',
+    source: 'postinstall',
+    stateIo: {
+      mkdir: async () => {
+        throw new Error('state directory denied')
+      }
+    },
+    statePath: resolveTelemetryStatePath({ env: { DSH_HOME: `${home}-blocked` } }),
+    transport: async ({ body }) => blockedSent.push(body)
+  })
+  if (blocked.status !== 'skipped' || blocked.reason !== 'state-unavailable') {
+    throw new Error(
+      `failed state write must skip with state-unavailable: ${JSON.stringify(blocked)}`
+    )
+  }
+  if (blockedSent.length !== 0) throw new Error('failed state write must not send')
+
+  // Concurrent first starts race the state read; the documented outcome is a
+  // possible double send with a parseable final state (never corruption).
+  const raceHome = `${home}-race`
+  const raceStatePath = resolveTelemetryStatePath({ env: { DSH_HOME: raceHome } })
+  const raceSent = []
+  const slowRead = async (file, options) => {
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 50))
+    return readFile(file, options)
+  }
+  const raceBase = {
+    buildInfo: { telemetryEndpoint: endpoint, commit: 'c0ffee', version: '9.9.9' },
+    env: { ...process.env, DSH_HOME: raceHome },
+    stateIo: { readFile: slowRead },
+    statePath: raceStatePath,
+    transport: async ({ body }) => raceSent.push(body.event)
+  }
+  await Promise.all([
+    runHostTelemetry({ ...raceBase, telemetryEnabled: true }),
+    runHostTelemetry({ ...raceBase, telemetryEnabled: true })
+  ])
+  if (raceSent.length < 2)
+    throw new Error(`concurrent starts must send at least the two events: ${raceSent.length}`)
+  parseTelemetryState(await readFile(raceStatePath, 'utf8'))
+
+  // The package.json lifecycle script exits immediately and delivers detached.
+  const shimHome = `${home}-shim`
+  const shimRequests = requests.length
+  const shim = await runProcess(
+    new URL('../scripts/telemetry-entry.mjs', import.meta.url).pathname,
+    ['postinstall'],
+    {
+      ...entryEnvironment,
+      DSH_HOME: shimHome
+    }
+  )
+  if (shim.status !== 0) throw new Error('lifecycle script must always exit 0')
+  await waitFor(() => requests.length > shimRequests, 'detached postinstall child never delivered')
+  if (requests[requests.length - 1].body.event !== 'dsh_plugin_postinstall')
+    throw new Error('shim sent the wrong event')
+
+  console.log('telemetry smoke passed')
+} finally {
+  server.close()
+  await rm(home, { force: true, recursive: true })
+}
+
+function assertPayloadShape(body) {
+  if (UUID_PATTERN.test(body.distinctId) !== true)
+    throw new Error(`distinct id must be a UUID: ${body.distinctId}`)
+  const keys = Object.keys(body.properties).toSorted()
+  if (keys.join(',') !== EXPECTED_PROPERTIES.join(','))
+    throw new Error(`unexpected payload keys: ${keys.join(',')}`)
+  if (body.properties.package_name !== 'dsh-univer-office') throw new Error('wrong package name')
+  if (
+    body.properties.package_version !== '9.9.9' &&
+    body.properties.package_version !== manifest.version
+  ) {
+    throw new Error(`wrong package version: ${body.properties.package_version}`)
+  }
+  if (body.properties.telemetry_state_version !== 1) throw new Error('wrong state version')
+}
+
+async function waitFor(predicate, message) {
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error(message)
+}


### PR DESCRIPTION
## What

Adds best-effort anonymous product telemetry to answer two questions from trend data only: how many installs activate, and how many stay active. Four allowlisted events travel through the Univer-owned proxy (`univer.ai/api/telemetry/cli`, allowlist shipped and verified in dream-num/univer.ai#696); the client never holds analytics credentials.

| Event | Trigger | Dedup |
| --- | --- | --- |
| `dsh_plugin_postinstall` | package postinstall hook, detached send | once per install identity |
| `dsh_plugin_activated` | host plugin activation | once per install identity |
| `dsh_plugin_daily_active` | host activation check | once per install identity per local day |
| `dsh_plugin_uninstall_hook` | package uninstall hook, detached send | never (state survives reinstall) |

## Design

- **Never affects install, activation, or uninstall**: every failure is swallowed, sends are bounded by a 5s timeout, no retries, no queues, no locks, no SDK. The Host pass is fire-and-forget and registers nothing; hook sends run in a detached child spawned by `scripts/telemetry-entry.mjs` (silent no-op when `lib/` is unbuilt).
- **At-most-once**: local-only state at `$DSH_HOME/telemetry/dsh-univer-office/state.json` (atomic tmp+rename, 0600) records each attempt *before* the first send; a crash loses an event rather than duplicating it. Concurrent starts may race and double-send once — accepted, the signal is read as a trend.
- **Payload allowlist only**: random UUID distinct id, package name/version, build commit, platform, arch, Node major version, event source, state schema version. No paths, workspace, session ids, file contents, or environment values. The proxy rejects unknown keys wholesale.
- **Opt-out everywhere**: `telemetry: false` (config; Host mirrors it into the state file so hook sends honor it too) and `DO_NOT_TRACK` short-circuit every entry point.
- **Endpoint pinning**: local builds pin an empty endpoint (fully inert); the release workflow injects `RELEASE_TELEMETRY_ENDPOINT` into published builds only. At runtime, an explicitly set `UNIVER_TELEMETRY_ENDPOINT` (including empty, as a kill switch) overrides the pinned value. Server allowlist was deployed and verified before this build path goes live.

## Validation

- `pnpm run typecheck`, `lint`, `test:integration`, `test:client`, `test:skills`, `test:telemetry` (new smoke: real entry CLI + real state files against a local proxy double — dedup, opt-out, disabled sync, payload shape, detached delivery), `git diff --check`.
- `pnpm pack --dry-run` ships `lib/telemetry-entry.js`, `lib/build-info.json`, `scripts/telemetry-entry.mjs`.
- Release-build simulation (endpoint pinned) passes the smoke via the runtime override; `test:host` has one pre-existing environment failure on root (chmod 0 bypassed) reproduced identically on clean `main`.
- Both READMEs gain a two-line telemetry note; `docs/architecture.md` documents events, state, and boundaries (§15); `AGENTS.md` gains the standing telemetry invariants and validation row.

## Post-merge

The next release through `Release to npm` is the first build that reports. No further coordination needed — the server allowlist is already live.