### PR TITLE
fix: hardcode the telemetry endpoint into every build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,10 +120,6 @@ jobs:
 
       - name: Build
         run: pnpm run build
-        env:
-          # Pin the live telemetry proxy into published builds only; local
-          # builds keep an empty endpoint and never send.
-          RELEASE_TELEMETRY_ENDPOINT: https://univer.ai/api/telemetry/cli
 
       - name: Test
         run: pnpm run test

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -404,7 +404,7 @@ Client 必须满足：
 
 产品遥测是 best-effort 的匿名活跃与卸载统计，只用于看趋势，不用于精确计量。发布包不声明 `postinstall`，以兼容 DSH profile 的依赖构建脚本审批策略。遥测绝不影响插件启动或卸载：所有失败静默吞掉，发送有 5 秒超时，无重试、无队列、无锁。
 
-- 事件共三个，统一经 `lib/build-info.json` 中固定的 Univer 代理 endpoint 上报（版本与 commit 也取自该文件），客户端不持有任何分析平台凭证。release workflow 通过 `RELEASE_TELEMETRY_ENDPOINT` 把线上代理地址注入发布构建；本地与开发构建保持为空，即遥测整体静默（`telemetry: false` 的 disabled 标记写入除外，见下）。运行时显式设置 `UNIVER_TELEMETRY_ENDPOINT`（含空值）优先于构建固定值，用作测试重定向与应急开关。服务端 allowlist 必须先于带 endpoint 的构建部署，否则事件会被整包拒绝且因 at-most-once 永久丢失；
+- 事件共三个，统一经 `lib/build-info.json` 中写死的 Univer 代理 endpoint 上报（版本与 commit 也取自该文件），客户端不持有任何分析平台凭证。发送只发生在安装后的插件激活与卸载钩子，开发 checkout 不会触发任何发送；telemetry smoke 断言构建产物中的 endpoint 等于写死地址，防止回归为静默构建。运行时显式设置 `UNIVER_TELEMETRY_ENDPOINT`（含空值）优先于写死值，用作测试重定向与应急开关。服务端 allowlist 必须先于带 endpoint 的构建部署，否则事件会被整包拒绝且因 at-most-once 永久丢失；
 - `dsh_plugin_activated`（Host 激活，每安装身份一次）、`dsh_plugin_daily_active`（Host 激活时检查，每安装身份每本地日一次）、`dsh_plugin_uninstall_hook`（包 uninstall，不去重，因为 state 跨重装存活，一次性标记会掩盖后续卸载）；
 - payload 只允许 `distinctId`（随机 UUID）、事件名与白名单属性（package name/version、build commit、platform、arch、Node major version、event source、state schema version），禁止路径、workspace、session、文件内容与环境变量。服务端代理对未知键整包拒绝；
 - 去重只在本机 state（`$DSH_HOME/telemetry/dsh-univer-office/state.json`，沿用 `config.ts` 的 `DSH_HOME` 约定）中做，先落盘标记再发送（at-most-once：崩溃宁可丢事件不重发，标记写失败时同样放弃发送）；并发启动的毫秒级竞态接受偶发双发；

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-univer-office",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "DSH × Univer integration with a bundled collaboration Gateway and Viewer: inline previews, live floating Worktree windows, and session-end review actions in DeepSeek Harness.",
   "type": "module",
   "main": "./lib/index.js",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -94,10 +94,12 @@ if (target === 'all' || target === 'lib') {
     sourcemap: false,
   })
 
-  // Telemetry endpoint: only the release workflow pins the live proxy address
-  // (RELEASE_TELEMETRY_ENDPOINT); local builds stay fully inert because an
-  // empty endpoint disables every send, including the uninstall hook.
-  const telemetryEndpoint = process.env.RELEASE_TELEMETRY_ENDPOINT ?? ''
+  // Telemetry endpoint hardcoded into every build: dev checkouts never invoke
+  // a sender (activation only runs inside an installed plugin), while runtime
+  // opt-outs (DO_NOT_TRACK, telemetry: false) and the UNIVER_TELEMETRY_ENDPOINT
+  // override still govern every send. The release workflow asserts the value
+  // before publishing, so a drift fails the release instead of going dark.
+  const telemetryEndpoint = 'https://univer.ai/api/telemetry/cli'
   const manifest = JSON.parse(await readFile('package.json', 'utf8'))
   let commit = ''
   try {

--- a/src/host/telemetry/product-telemetry.ts
+++ b/src/host/telemetry/product-telemetry.ts
@@ -107,9 +107,9 @@ export function resolveTelemetryStatePath(
 
 /**
  * Resolution order: an explicitly set `UNIVER_TELEMETRY_ENDPOINT` (even empty,
- * which disables telemetry) wins over the value pinned into the build by the
- * release workflow, so tests and incident response can always redirect or cut
- * the endpoint. An empty result disables telemetry entirely.
+ * which disables telemetry) wins over the address hardcoded into the build, so
+ * tests and incident response can always redirect or cut the endpoint. An
+ * empty result disables telemetry entirely.
  */
 export function telemetryEndpointFor(input: {
   readonly buildInfo: TelemetryBuildInfo

--- a/test/telemetry-smoke.mjs
+++ b/test/telemetry-smoke.mjs
@@ -35,12 +35,9 @@ if (resolveConfig().telemetry !== true || resolveConfig({ telemetry: false }).te
 const buildInfo = JSON.parse(
   await readFile(new URL('../lib/build-info.json', import.meta.url), 'utf8')
 )
-// Local builds pin an empty endpoint; the release workflow pins the live proxy.
-// Anything else in build-info means the pin drifted from the reviewed target.
-if (
-  buildInfo.telemetryEndpoint !== '' &&
-  buildInfo.telemetryEndpoint !== 'https://univer.ai/api/telemetry/cli'
-) {
+// Every build hardcodes the live proxy address; anything else in build-info
+// means the constant drifted without review and releases would ship silent.
+if (buildInfo.telemetryEndpoint !== 'https://univer.ai/api/telemetry/cli') {
   throw new Error(`unexpected pinned telemetry endpoint: ${buildInfo.telemetryEndpoint}`)
 }
 if (buildInfo.version !== manifest.version) {
@@ -115,7 +112,7 @@ try {
   }
 
   // An explicitly empty endpoint override stays fully inert even when the
-  // build pins the live proxy (release CI builds and incident kill-switch).
+  // build pins the live proxy (incident kill-switch and CI test isolation).
   const inertHome = `${home}-inert`
   await runProcess(entryPath, ['capture', 'dsh_plugin_uninstall_hook'], {
     ...process.env,


### PR DESCRIPTION
## Root cause

0.2.11 and 0.2.12 shipped **fully silent** (zero telemetry): the release workflow pinned the proxy via a Build-step `env`, but the Test step reruns `pnpm run build` (first command of `pnpm test`) **without** that env — the rebuild rewrote `lib/build-info.json` with `"telemetryEndpoint": ""`, and the pack published the wiped artifact. Run 33358402089's log shows both builds; the published 0.2.12 tarball confirms the empty endpoint.

## Fix

- `scripts/build.mjs` hardcodes `https://univer.ai/api/telemetry/cli` into `lib/build-info.json` — no env can wipe it, and dev checkouts never invoke a sender (activation only runs inside an installed plugin; the uninstall hook is not fired by npm/pnpm dependency removal).
- The release workflow drops the env plumbing and gains a **Verify pinned telemetry endpoint** step before publishing, so a silent build fails the release instead of shipping dark.
- Runtime governance is unchanged: `DO_NOT_TRACK`, `telemetry: false`, and an explicit `UNIVER_TELEMETRY_ENDPOINT` override (including empty as a kill switch) still govern every send; the smoke's redirect cases cover them.
- The smoke now asserts the endpoint equals the pinned address exactly (drift = red), and `package.json` bumps to **0.2.13** so the next workflow run publishes the fix with no inputs.

## Validation

- Exact CI sequence locally: `pnpm run build` → `pnpm run test:telemetry` → build-info still pinned; the new release gate command passes against the same artifact.
- `typecheck` (exit 0), oxlint + oxfmt clean on changed files, `git diff --check`.
- Existing 0.2.11/0.2.12 installs stay inert by design (endpoint baked empty); machines that upgrade to the next version report `dsh_plugin_activated` + `dsh_plugin_daily_active` from a fresh install identity.