### PR TITLE
feat: suffix telemetry versions of NODE_ENV=development builds with -dev

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -372,6 +372,8 @@ Client 必须满足：
 
 发布包包含运行所需的 Gateway、Viewer、Unit Content Worker、Office 转换器、平台依赖、Univer license 与 bundled Skills。Gateway、Worker、Viewer 和 Host 直接使用 manifest 中精确版本的 Univer SDK/API Reference packages；JavaScript SDK 被 bundle，平台原生 package 由包管理器为目标机器安装。发布时只打包从当前源码生成的运行产物。
 
+仓库内 `package.json` 的版本即真实版本；发布版本号由 CI 通过 version 输入或 `v*` tag 指定并注入后构建，发布目标拒绝带 `-dev` 后缀或 `0.0.0`。制品的受众在构建时确定：`NODE_ENV=development` 下构建的产物（本地与内部测试安装包）版本带 `-dev` 后缀，release 构建不带，遥测原样上报构建时写入的版本。
+
 原生公式引擎、Office 转换器与 SQLite 依赖仍具有平台属性。release workflow 必须在目标平台安装 lockfile 所指定的依赖后构建和测试，不能把一个平台的 `node_modules` 复制为通用发布物。
 
 ## 13. 验证策略

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -97,10 +97,15 @@ if (target === 'all' || target === 'lib') {
   // Telemetry endpoint hardcoded into every build: dev checkouts never invoke
   // a sender (activation only runs inside an installed plugin), while runtime
   // opt-outs (DO_NOT_TRACK, telemetry: false) and the UNIVER_TELEMETRY_ENDPOINT
-  // override still govern every send. The release workflow asserts the value
-  // before publishing, so a drift fails the release instead of going dark.
+  // override still govern every send.
   const telemetryEndpoint = 'https://univer.ai/api/telemetry/cli'
+  // The artifact's audience is fixed at build time: builds made with
+  // NODE_ENV=development (local packs, team test installs) report a `-dev`
+  // suffixed version; release builds run without NODE_ENV and report the bare
+  // package.json version. Reporting sends whatever is baked in here verbatim.
   const manifest = JSON.parse(await readFile('package.json', 'utf8'))
+  const telemetryVersion =
+    process.env.NODE_ENV === 'development' ? `${manifest.version}-dev` : manifest.version
   let commit = ''
   try {
     commit = execFileSync('git', ['rev-parse', 'HEAD'], { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
@@ -109,7 +114,7 @@ if (target === 'all' || target === 'lib') {
   }
   await writeFile(
     'lib/build-info.json',
-    `${JSON.stringify({ commit, telemetryEndpoint, version: manifest.version }, null, 2)}\n`
+    `${JSON.stringify({ commit, telemetryEndpoint, version: telemetryVersion }, null, 2)}\n`
   )
   console.log('built lib/index.js + lib/client.js + lib/telemetry-entry.js')
 }

--- a/test/telemetry-smoke.mjs
+++ b/test/telemetry-smoke.mjs
@@ -40,6 +40,8 @@ const buildInfo = JSON.parse(
 if (buildInfo.telemetryEndpoint !== 'https://univer.ai/api/telemetry/cli') {
   throw new Error(`unexpected pinned telemetry endpoint: ${buildInfo.telemetryEndpoint}`)
 }
+// build-info tracks package.json verbatim: a `-dev`-suffixed version marks a
+// source build, the release workflow injects the clean published version.
 if (buildInfo.version !== manifest.version) {
   throw new Error(`build-info version must track package.json: ${buildInfo.version}`)
 }
@@ -253,6 +255,27 @@ try {
   if (requests[requests.length - 1].body.event !== 'dsh_plugin_uninstall_hook')
     throw new Error('shim sent the wrong event')
 
+  // The artifact's audience is fixed at build time: a NODE_ENV=development
+  // rebuild reports the -dev-suffixed version, a clean rebuild the bare one.
+  // Runs last because it overwrites lib/, and restores the clean form after.
+  const rebuildLib = async (nodeEnv) =>
+    runProcess(new URL('../scripts/build.mjs', import.meta.url).pathname, ['lib'], {
+      ...process.env,
+      NODE_ENV: nodeEnv
+    })
+  const devBuild = await rebuildLib('development')
+  if (devBuild.status !== 0) throw new Error(`development rebuild must succeed: ${devBuild.status}`)
+  const devInfo = JSON.parse(await readFile(new URL('../lib/build-info.json', import.meta.url), 'utf8'))
+  if (devInfo.version !== `${manifest.version}-dev`) {
+    throw new Error(`development build must suffix the version: ${devInfo.version}`)
+  }
+  const cleanBuild = await rebuildLib('')
+  if (cleanBuild.status !== 0) throw new Error(`clean rebuild must succeed: ${cleanBuild.status}`)
+  const cleanInfo = JSON.parse(await readFile(new URL('../lib/build-info.json', import.meta.url), 'utf8'))
+  if (cleanInfo.version !== manifest.version) {
+    throw new Error(`clean build must report the bare version: ${cleanInfo.version}`)
+  }
+
   console.log('telemetry smoke passed')
 } finally {
   server.close()
@@ -266,10 +289,7 @@ function assertPayloadShape(body) {
   if (keys.join(',') !== EXPECTED_PROPERTIES.join(','))
     throw new Error(`unexpected payload keys: ${keys.join(',')}`)
   if (body.properties.package_name !== 'dsh-univer-office') throw new Error('wrong package name')
-  if (
-    body.properties.package_version !== '9.9.9' &&
-    body.properties.package_version !== manifest.version
-  ) {
+  if (body.properties.package_version !== '9.9.9' && body.properties.package_version !== manifest.version) {
     throw new Error(`wrong package version: ${body.properties.package_version}`)
   }
   if (body.properties.telemetry_state_version !== 1) throw new Error('wrong state version')


### PR DESCRIPTION
## Why

With the telemetry endpoint hardcoded, any source build reports real events — and internal test installs reported the bare `package.json` version, indistinguishable in PostHog from a released version.

## Framing

The dev-vs-release distinction is a property of the **artifact**, decided when we build it — not of the runtime where DSH loads it. So the marker moved into the build, and reporting stays dumb.

## What (3 files, no workflow changes, no new env vars)

- `scripts/build.mjs`: builds made with `NODE_ENV=development` (the standard JS convention — local packs, team test installs) bake a `-dev`-suffixed version into `build-info.json`; release builds run without `NODE_ENV` (GitHub Actions doesn't set it) and bake the bare `0.2.13`.
- Reporting sends `build-info.json` verbatim — zero runtime logic; the earlier runtime-suffix experiment was removed.
- The smoke now **rebuilds both forms and asserts each** (`NODE_ENV=development` → `0.2.13-dev`, clean → `0.2.13`), restoring the clean form afterwards so packaging is unaffected. It runs last in the chain, so the release CI pack still publishes the clean build.
- `docs/architecture.md` §12 documents the build-time marker.

## Usage

- Local test packs: `NODE_ENV=development pnpm run build && npm pack` → events report `0.2.13-dev`.
- Releases: dispatch `Release to npm` as usual (no `NODE_ENV` in CI) → events report `0.2.13`.

## Validation

Two-rebuild matrix asserted inside the smoke (green), plus the full existing smoke (dedup, opt-out, gating, race, shim), `typecheck` exit 0, oxlint + oxfmt clean, `git diff --check`. Diff is 3 files; `package.json`, `scripts/telemetry-entry.mjs`, and the release workflow carry no changes.