### PR TITLE
feat: add Unit PDF printing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ Create a sales Sheet and a summary Slide in the same .univer file, with the Slid
 
 | Content | Create and edit | Verify and review | Import | Export |
 | --- | --- | --- | --- | --- |
-| Sheet | Cells, formulas, styles, tables, charts, pivots, filters, validation, images, and more | Structured range inspection, recalculation, range/workbook screenshots, live preview | `.xlsx` `.csv` `.tsv` | `.xlsx` `.csv` `.tsv` |
-| Doc | Paragraphs, rich text, lists, tasks, tables, images, charts, headers, footers, pagination | Document readback, page screenshots, live preview | `.docx` | `.docx` |
-| Slide | Pages, text, shapes, images, tables, charts, SVG layouts, transitions | Structure inspection, text bounds/overflow/overlap lint, page/contact-sheet screenshots, live preview | `.pptx` | `.pptx` |
+| Sheet | Cells, formulas, styles, tables, charts, pivots, filters, validation, images, and more | Structured range inspection, recalculation, screenshots, PDF printing, live preview | `.xlsx` `.csv` `.tsv` | `.xlsx` `.csv` `.tsv` |
+| Doc | Paragraphs, rich text, lists, tasks, tables, images, charts, headers, footers, pagination | Document readback, page screenshots, PDF printing, live preview | `.docx` | `.docx` |
+| Slide | Pages, text, shapes, images, tables, charts, SVG layouts, transitions | Structure inspection, layout lint, screenshots, PDF printing, live preview | `.pptx` | `.pptx` |
 | Base | Tables, fields, records, views, formulas, filters, sorting, grouping | Structured data checks, workbench screenshot, live preview | — | `.xlsx` `.csv` `.tsv` |
-| Board | Shapes, text, connectors, images, native charts, routing | Element and connector analysis, overview/region/element screenshots, live preview | — | — |
+| Board | Shapes, text, connectors, images, native charts, routing | Element analysis, screenshots, PDF printing, live preview | — | — |
 
 Every content type supports isolated draft editing, review, revision, approval, and discarding. Base and Board support structural verification; Board file export is not yet supported.
 
@@ -162,6 +162,7 @@ DSH selects these tools automatically; you normally do not need to call them man
 | `univer_lint` | Find off-page, overflowing, and overlapping Slide text |
 | `univer_compile_svg` | Add an SVG layout to a Slide with measured text |
 | `univer_screenshot` | Render supported content as PNG images for review |
+| `univer_print_pdf` | Print a Sheet, Doc, Slide, or Board to a workspace PDF file |
 | `univer_api` | Find bundled Univer API symbols by keyword and show exact references |
 | `univer_resources` | Find and use bundled icons, logos, emoji, and illustrations |
 
@@ -195,6 +196,7 @@ The defaults are designed for local use: the service starts at port `9080`. If t
 | `gatewayMutationTimeoutMs` | `60000` | Write-operation timeout |
 | `unitContentOperationTimeoutMs` | `120000` | Import, export, inspection, and execution timeout |
 | `screenshotOperationTimeoutMs` | `120000` | Overall timeout for one browser screenshot operation |
+| `printPdfOperationTimeoutMs` | `120000` | Overall timeout for one browser PDF print operation |
 | `screenshotMaxPages` | `30` | Maximum Doc or Slide pages rendered by one screenshot call |
 | `screenshotMaxPixels` | `16777216` | Maximum pixel count for each screenshot image |
 | `resourceCacheRoot` | `$DSH_HOME/cache/dsh-univer-office/resources` | Persistent downloaded-SVG cache; falls back to `~/.dsh` when `DSH_HOME` is unset |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,11 +94,11 @@ Agent 可以根据主题、受众、页数、内容结构和视觉要求生成�
 
 | 内容类型 | 创建与编辑 | 校验与审阅 | 导入 | 导出 |
 | --- | --- | --- | --- | --- |
-| Sheet | 单元格、公式、样式、表格、图表、透视表、筛选、验证、图片等 | 结构化范围检查、公式重算、范围/工作簿截图、实时预览 | `.xlsx` `.csv` `.tsv` | `.xlsx` `.csv` `.tsv` |
-| Doc | 段落、富文本、列表、任务、表格、图片、图表、页眉页脚、分页 | 文档结构回读、逐页截图、实时预览 | `.docx` | `.docx` |
-| Slide | 页面、文字、形状、图片、表格、图表、SVG 布局、转场 | 结构检查、文字越界/溢出/重叠检查、逐页/联系表截图、实时预览 | `.pptx` | `.pptx` |
+| Sheet | 单元格、公式、样式、表格、图表、透视表、筛选、验证、图片等 | 结构化范围检查、公式重算、截图、PDF 打印、实时预览 | `.xlsx` `.csv` `.tsv` | `.xlsx` `.csv` `.tsv` |
+| Doc | 段落、富文本、列表、任务、表格、图片、图表、页眉页脚、分页 | 文档结构回读、逐页截图、PDF 打印、实时预览 | `.docx` | `.docx` |
+| Slide | 页面、文字、形状、图片、表格、图表、SVG 布局、转场 | 结构检查、布局检查、截图、PDF 打印、实时预览 | `.pptx` | `.pptx` |
 | 多维表格（Base） | 表、字段、记录、视图、公式字段、筛选、排序、分组 | 结构化数据检查、工作台截图、实时预览 | — | `.xlsx` `.csv` `.tsv` |
-| Board | 形状、文字、连接线、图片、原生图表、自动布线 | 元素与连接关系分析、全局/区域/元素截图、实时预览 | — | — |
+| Board | 形状、文字、连接线、图片、原生图表、自动布线 | 元素分析、截图、PDF 打印、实时预览 | — | — |
 
 所有类型都支持隔离草稿、审阅、继续修改、确认或放弃。多维表格和 Board 支持结构校验；Board 暂不支持文件导出。
 
@@ -162,6 +162,7 @@ DSH 会自动选择这些工具，日常使用不需要手动调用。
 | `univer_lint` | 检查 Slide 文字越界、溢出和重叠 |
 | `univer_compile_svg` | 将 SVG 布局按文字度量添加到 Slide |
 | `univer_screenshot` | 把支持的内容渲染为 PNG 图片供审阅 |
+| `univer_print_pdf` | 把 Sheet、Doc、Slide 或 Board 打印为 workspace 中的 PDF 文件 |
 | `univer_api` | 按关键词查找插件内置的 Univer API 符号并查看精确引用 |
 | `univer_resources` | 查找和使用内置图标、Logo、Emoji 与插画 |
 
@@ -195,6 +196,7 @@ DSH 会自动选择这些工具，日常使用不需要手动调用。
 | `gatewayMutationTimeoutMs` | `60000` | 写操作超时 |
 | `unitContentOperationTimeoutMs` | `120000` | 导入、导出、检查和执行超时 |
 | `screenshotOperationTimeoutMs` | `120000` | 一次浏览器截图操作的总超时 |
+| `printPdfOperationTimeoutMs` | `120000` | 一次浏览器 PDF 打印操作的总超时 |
 | `screenshotMaxPages` | `30` | 一次 Doc 或 Slide 截图最多渲染的页数 |
 | `screenshotMaxPixels` | `16777216` | 每张截图允许的最大像素数 |
 | `resourceCacheRoot` | `$DSH_HOME/cache/dsh-univer-office/resources` | 下载 SVG 资源的持久缓存目录；未设置 `DSH_HOME` 时使用 `~/.dsh` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,8 +97,8 @@ src/
       plugin.ts                      # Service Provider
       gateway-univer-service.ts      # 服务实现
       unit-content-operations.ts     # Unit 内容操作
-      render-source-operations.ts    # 截图主 Unit、引用 Unit 与图片资源装配
-      render-operations.ts           # browser-backed lint、SVG 编译与截图
+      render-source-operations.ts    # 渲染主 Unit、引用 Unit 与图片资源装配
+      render-operations.ts           # browser-backed lint、SVG 编译、截图与 PDF 打印
       resource-operations.ts         # 内置 SVG registry、缓存与安全导出
       worktree-operations.ts         # worktree 领域操作
       state-cache.ts                 # 有明确失效规则的缓存
@@ -127,6 +127,7 @@ src/
         lint.ts
         compile-svg.ts
         screenshot.ts
+        print-pdf.ts
         api.ts
         resources.ts
     skills/
@@ -260,7 +261,7 @@ bundled skill provider -> DSH skill registry
 - File 与状态：创建空 `.univer` 容器，读取 trunk、worktree 与 Unit 状态；
 - Collaboration：创建 worktree，执行 ready、reopen、merge 与 discard 生命周期操作；
 - Unit Content：在 draft worktree 中创建、移除或导入 Unit，以及检查、执行、导出和读取 machine render snapshot；
-- Render：对 Slide snapshot 执行布局检查，把 SVG 编译为 Facade program 并提交到显式 draft worktree，以及为显式 Unit、依赖 Unit 和图片资源装配渲染源并生成 PNG；
+- Render：对 Slide snapshot 执行布局检查，把 SVG 编译为 Facade program 并提交到显式 draft worktree，以及为显式 Unit、依赖 Unit 和图片资源装配渲染源并生成 PNG 或 PDF；
 - API Reference：查找 API 候选并读取指定 Facade/方法的完整参考。
 - Resource Library：列出 registry、按语义搜索、读取 SVG、导出到显式 workspace 目录和清理 Provider-owned 缓存。
 
@@ -316,12 +317,13 @@ Tools Consumer 注册面向模型的领域工具，而不是一个透传 CLI 的
 - `univer_lint`
 - `univer_compile_svg`
 - `univer_screenshot`
+- `univer_print_pdf`
 - `univer_api`
 - `univer_resources`
 
 每个工具有独立的参数 schema、结果 schema、超时/取消处理和纯 presentation。工具结果必须包含恢复 Client 预览目标所需的结构化文件、worktree 与 unit 标识，并进入 DSH 会话日志。领域失败使用 DSH 可持久化的稳定错误 code，并在模型可见文本中保留 `Error [CODE]`，使 Agent 不必解析自然语言即可选择恢复路径。Client 优先从 `tool/call` 与 `tool/result` 事件恢复目标，不依赖 bash 文本解析。
 
-`univer_status` 是发现文件状态与显式 Unit ID 的入口。所有内容工具要求显式 Unit ID，所有文件和输出路径都绑定当前 tool exec session 的 workspace，并在 Provider 边界再次验证。`univer_screenshot` 在读取文件前确认 attachment service、PNG 限制与当前模型图片输入能力，生成文件再次经过 workspace realpath 授权，再保存为持久 DSH image attachment；结构化文本保留恢复目标与图片元数据。`univer_resources` 的 cache root 只由 Provider 配置拥有，不向模型暴露；export 目录和每个实际输出文件都必须通过 workspace 授权。`ready` 提交修改等待审阅；同一任务需要继续修改时用 `reopen`。`merge` 与 `discard` 只有在用户明确要求时才可调用，并通过 `tools/pre-execute` 返回审批请求，不能由模型自行决定。
+`univer_status` 是发现文件状态与显式 Unit ID 的入口。所有内容工具要求显式 Unit ID，所有文件和输出路径都绑定当前 tool exec session 的 workspace，并在 Provider 边界再次验证。`univer_screenshot` 在读取文件前确认 attachment service、PNG 限制与当前模型图片输入能力，生成文件再次经过 workspace realpath 授权，再保存为持久 DSH image attachment；结构化文本保留恢复目标与图片元数据。`univer_print_pdf` 复用同一渲染源与 Render Machine，把 Sheet、Doc、Slide 或 Board 写入授权的 `.pdf` 路径，不支持 Base。`univer_resources` 的 cache root 只由 Provider 配置拥有，不向模型暴露；export 目录和每个实际输出文件都必须通过 workspace 授权。`ready` 提交修改等待审阅；同一任务需要继续修改时用 `reopen`。`merge` 与 `discard` 只有在用户明确要求时才可调用，并通过 `tools/pre-execute` 返回审批请求，不能由模型自行决定。
 
 包内 `univer` Skill 描述完整编排顺序，sheet、doc、slide、base 与 board Skill 只在对应 Unit 工作时按需加载，Embed 与跨 Unit 公式各有 Topic Skill。内容以同版本 Univer CLI runtime Skills 为基线：只移除插件未开放的 command，并把 CLI command 调用替换为结构化 DSH Tool 或 Client 自动预览。Slide Skill 要求新页面主动使用 `univer_compile_svg`，结构检查后对每个变更页运行 `univer_lint`，最终逐页运行 `univer_screenshot`；其他 Unit Skill 使用其范围、分页、工作台或画布截图目标。需要图标、Logo、Emoji 或插画时先通过 `univer_resources` 查找和导出。不确定或可能随 SDK 变化的 API 必须通过 `univer_api` 查询。
 
@@ -333,7 +335,7 @@ Client 是状态投影，不拥有 worktree 真相。预览目标来自可回放
 
 Client 通过 `univerTurnDefinition` 按 `callId` 配对结构化工具调用与结果，并分别归约生命周期、内容写入和读取操作；读取操作不能覆盖同一 Turn 已完成的 ready、reopen、merge 或 discard 转换。统一回合卡片把该投影与 Host `FileState` 组合，按权威状态打开 trunk、worktree 或 merge preview 完整页面；若 Host 明确确认投影中的文件已不存在，则不渲染该卡片，以覆盖 Agent 在同一 Turn 中创建并通过其他工具删除临时文件的场景。
 
-实时浮窗只由 `univer_new`、worktree create/reopen/ready 和内容写入主动拉起，纯 status、inspect、lint、screenshot 与 export 不主动打开窗口。用户保持打开的文件或非终态 worktree 会在下一 Turn 继续显示；用户关闭优先，merged 与 discarded 清除打开意图。
+实时浮窗只由 `univer_new`、worktree create/reopen/ready 和内容写入主动拉起，纯 status、inspect、lint、screenshot、print-pdf 与 export 不主动打开窗口。用户保持打开的文件或非终态 worktree 会在下一 Turn 继续显示；用户关闭优先，merged 与 discarded 清除打开意图。
 
 `univer-office` Settings 命名空间拥有 `autoOpenLivePreview` 用户偏好，默认开启且实时生效。Settings 服务或对应 Client 设置表面缺席时，Client 保持默认开启，不让可选设置能力阻塞预览与审阅注册；关闭该偏好只移除实时浮窗及其轮询，回合尾部审阅投影不受影响。
 
@@ -362,9 +364,10 @@ Client 必须满足：
 5. `univer_lint` 只返回布局 coverage 与 findings，不生成或返回图片；
 6. `univer_compile_svg` 只读取 session workspace 内的 SVG 与引用资源，并把生成程序提交到显式 draft worktree；
 7. `univer_screenshot` 复用随包 Render Machine，显式装配目标 Unit、公式引用 Unit、Embed child Unit 与 Gateway 图片资源，PNG 同时落到授权 workspace 和 DSH attachment；
-8. `univer_resources` 复用随包 manifest 与 HTTPS-only resource library，不调用外部 CLI，缓存位置来自已校验配置；
-9. Client 只从结构化工具事件恢复预览目标；
-10. 全新环境仅安装本插件即可完成创建、导入、修改、检查、布局 lint、SVG 页面编译、截图、资源查找/导出、Office 导出、预览和 worktree 修改审阅。
+8. `univer_print_pdf` 复用同一 Render Machine 与完整渲染源，把支持的 Unit 打印到授权 workspace PDF；
+9. `univer_resources` 复用随包 manifest 与 HTTPS-only resource library，不调用外部 CLI，缓存位置来自已校验配置；
+10. Client 只从结构化工具事件恢复预览目标；
+11. 全新环境仅安装本插件即可完成创建、导入、修改、检查、布局 lint、SVG 页面编译、截图、PDF 打印、资源查找/导出、Office 导出、预览和 worktree 修改审阅。
 
 ## 12. 构建与发布
 
@@ -382,7 +385,7 @@ Client 必须满足：
 - `provider`：路径 scope、缓存失效、Gateway 映射、worktree 状态与错误；
 - `webServer`：method、JSON、字段、会话授权和错误响应；
 - `tools`：schema、取消、结构化结果和 presentation；
-- `render/resources`：截图依赖装配、页数/像素/attachment 限制、资源下载取消、cache 隔离与 export 路径授权；
+- `render/resources`：截图/PDF 依赖装配、页数/像素/attachment 限制、资源下载取消、cache 隔离与 export 路径授权；
 - `skills`：发现顺序、按需加载、frontmatter 剥离和发布包收录；
 - `client`：事件恢复、轮询生命周期、浮窗交互、unit 切换和审阅 mutation；
 - `integration`：无全局 CLI 的全新环境中，仅安装插件完成端到端功能。

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@univer-cli/resource-library": "1.0.0-insiders.20260902-a58c423",
     "@univer-cli/svg-facade": "1.0.0-insiders.20260902-a58c423",
     "@univer-cli/unit-layout-lint": "1.0.0-insiders.20260902-a58c423",
+    "@univer-cli/unit-pdf-printer": "1.0.0-insiders.20260902-a58c423",
     "@univer-cli/unit-screenshot": "1.0.0-insiders.20260902-a58c423",
     "@univer-cli/univer-collaboration-runtime": "1.0.0-insiders.20260902-a58c423",
     "@univer-cli/univer-render-page": "1.0.0-insiders.20260902-a58c423",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@univer-cli/unit-layout-lint':
         specifier: 1.0.0-insiders.20260902-a58c423
         version: 1.0.0-insiders.20260902-a58c423(react@18.3.1)(rxjs@7.8.2)
+      '@univer-cli/unit-pdf-printer':
+        specifier: 1.0.0-insiders.20260902-a58c423
+        version: 1.0.0-insiders.20260902-a58c423(react@18.3.1)(rxjs@7.8.2)
       '@univer-cli/unit-screenshot':
         specifier: 1.0.0-insiders.20260902-a58c423
         version: 1.0.0-insiders.20260902-a58c423(react@18.3.1)(rxjs@7.8.2)
@@ -2547,6 +2550,9 @@ packages:
 
   '@univer-cli/unit-layout-lint@1.0.0-insiders.20260902-a58c423':
     resolution: {integrity: sha512-2RCBOsGPzMQLPYBA4UzUY3zdL4a0ACWTvcSQYM5HidGgzJk30b/CTPXKYA/VKOaYcy+M6PG3JjafDh7Nzg4x0w==}
+
+  '@univer-cli/unit-pdf-printer@1.0.0-insiders.20260902-a58c423':
+    resolution: {integrity: sha512-Lf2CXl8fsvFE+nYJCKNQWf4JGKFlJU8mb/YCqDx5yB7GffbrpS8ztuPfYF+CUhpQmJjhOA8zxuQLVZpFtF0u2w==}
 
   '@univer-cli/unit-screenshot@1.0.0-insiders.20260902-a58c423':
     resolution: {integrity: sha512-EIzUeNpRa3yCiiCZara4pB6R+VQlQ0SJvmXEVYao7DzDWV7LWvw1gHAQKa1pFZtjSC24Sq1kmkJ6TYFUooAZCg==}
@@ -5984,6 +5990,17 @@ snapshots:
   '@univer-cli/svg-facade@1.0.0-insiders.20260902-a58c423': {}
 
   '@univer-cli/unit-layout-lint@1.0.0-insiders.20260902-a58c423(react@18.3.1)(rxjs@7.8.2)':
+    dependencies:
+      '@univer-cli/univer-render-runtime': 1.0.0-insiders.20260902-a58c423(react@18.3.1)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - proxy-agent
+      - react
+      - rxjs
+      - utf-8-validate
+      - yauzl
+
+  '@univer-cli/unit-pdf-printer@1.0.0-insiders.20260902-a58c423(react@18.3.1)(rxjs@7.8.2)':
     dependencies:
       '@univer-cli/univer-render-runtime': 1.0.0-insiders.20260902-a58c423(react@18.3.1)(rxjs@7.8.2)
     transitivePeerDependencies:

--- a/skills/univer/SKILL.md
+++ b/skills/univer/SKILL.md
@@ -55,7 +55,7 @@ Only `colorEditable: true` resources may follow an authored color. Fixed logos, 
 7. Read the changed scope with `univer_inspect`; use a fresh read-only `univer_execute` when inspection omits a required model field.
 8. For every changed Slide page, call `univer_lint` and resolve or explicitly justify each finding.
 9. For visually relevant changes, call `univer_screenshot` with an explicit workspace output directory and the narrowest useful Unit-specific target. Inspect every returned image; screenshots complement rather than replace structural readback or Slide lint.
-10. Export with `univer_export` only when requested and only from the verified scope.
+10. Export with `univer_export`, or print a PDF with `univer_print_pdf`, only when requested and only from the verified scope.
 11. Mark the worktree `ready` and confirm it with `univer_status`.
 
 `univer_screenshot` returns model-visible PNG evidence and writes the same PNGs under its explicit `output` directory. It requires an image-capable current model route. The DSH client also renders live worktree content and the ready review panel from tool results; that preview remains the user-facing handoff surface because there is no model-facing show/open tool. Claim visual verification only for images actually inspected in the current result.
@@ -90,6 +90,7 @@ Never reopen or reuse a merged or discarded worktree; create a new worktree inst
 | Reference | `univer_api` | Find an unknown name, or show a known class, API, or type. |
 | Reference | `univer_resources` | List/find/read/export bundled SVG resources or clear their download cache. |
 | Deliver | `univer_export` | Export Sheet/Base to xlsx/csv/tsv, Doc to docx, or Slide to pptx. |
+| Deliver | `univer_print_pdf` | Print Sheet, Doc, Slide, or Board from trunk or a worktree to an explicit PDF path. |
 
 ## Facade execution
 
@@ -119,10 +120,11 @@ Read only task assets inside the session workspace. Do not print or return the d
 - Export Sheet or Base to `.xlsx`, `.csv`, or `.tsv`; Doc to `.docx`; Slide to `.pptx`.
 - Board export is unsupported.
 - Export uses an explicit Unit and an explicit trunk or worktree scope. Recalculate formulas and finish readback before exporting.
+- PDF printing supports Sheet, Doc, Slide, and Board; Base is not printable. Use an explicit Unit, output path ending in `.pdf`, and the same verified trunk or worktree scope.
 
 ## Unsupported CLI-only capabilities
 
-Do not invent equivalents for CLI maintenance, daemon/configuration, `compile-typst`, optimization, or shell command help. Use the bundled DSH tools for resources and screenshots; if the task requires another missing capability, report that exact gap.
+Do not invent equivalents for CLI maintenance, daemon/configuration, `compile-typst`, optimization, or shell command help. Use the bundled DSH tools for resources, screenshots, and PDF printing; if the task requires another missing capability, report that exact gap.
 
 ## Failure recovery
 

--- a/skills/univer/SKILL.md
+++ b/skills/univer/SKILL.md
@@ -89,8 +89,7 @@ Never reopen or reuse a merged or discarded worktree; create a new worktree inst
 | Verify | `univer_screenshot` | Render Sheet, Doc, Slide, Base, or Board PNG evidence and return it to an image-capable model. |
 | Reference | `univer_api` | Find an unknown name, or show a known class, API, or type. |
 | Reference | `univer_resources` | List/find/read/export bundled SVG resources or clear their download cache. |
-| Deliver | `univer_export` | Export Sheet/Base to xlsx/csv/tsv, Doc to docx, or Slide to pptx. |
-| Deliver | `univer_print_pdf` | Print Sheet, Doc, Slide, or Board from trunk or a worktree to an explicit PDF path. |
+| Deliver | `univer_export` / `univer_print_pdf` | Export Office files or print Sheet, Doc, Slide, or Board to PDF. |
 
 ## Facade execution
 
@@ -120,11 +119,10 @@ Read only task assets inside the session workspace. Do not print or return the d
 - Export Sheet or Base to `.xlsx`, `.csv`, or `.tsv`; Doc to `.docx`; Slide to `.pptx`.
 - Board export is unsupported.
 - Export uses an explicit Unit and an explicit trunk or worktree scope. Recalculate formulas and finish readback before exporting.
-- PDF printing supports Sheet, Doc, Slide, and Board; Base is not printable. Use an explicit Unit, output path ending in `.pdf`, and the same verified trunk or worktree scope.
 
 ## Unsupported CLI-only capabilities
 
-Do not invent equivalents for CLI maintenance, daemon/configuration, `compile-typst`, optimization, or shell command help. Use the bundled DSH tools for resources, screenshots, and PDF printing; if the task requires another missing capability, report that exact gap.
+Do not invent equivalents for CLI maintenance, daemon/configuration, `compile-typst`, optimization, or shell command help. Use the bundled DSH tools for resources and screenshots; if the task requires another missing capability, report that exact gap.
 
 ## Failure recovery
 

--- a/src/client/conversation/univer-turn-definition.ts
+++ b/src/client/conversation/univer-turn-definition.ts
@@ -16,6 +16,7 @@ export type UniverOperationName =
   | 'export'
   | 'lint'
   | 'screenshot'
+  | 'print-pdf'
   | 'compile-svg'
 export type UniverOperationPhase = 'pending' | 'succeeded' | 'failed'
 export type UniverTurnLifecycle = 'trunk' | 'draft' | 'ready' | 'merged' | 'discarded' | 'unchanged'
@@ -284,6 +285,7 @@ function operationName(name: string): UniverOperationName | null {
     operation === 'export' ||
     operation === 'lint' ||
     operation === 'screenshot' ||
+    operation === 'print-pdf' ||
     operation === 'compile-svg'
   )
     return operation

--- a/src/host/config.ts
+++ b/src/host/config.ts
@@ -18,6 +18,8 @@ export interface Config {
   unitContentOperationTimeoutMs?: number
   /** Maximum lifetime of one browser-backed screenshot operation. */
   screenshotOperationTimeoutMs?: number
+  /** Maximum lifetime of one browser-backed PDF print operation. */
+  printPdfOperationTimeoutMs?: number
   /** Maximum number of document or slide pages captured by one screenshot call. */
   screenshotMaxPages?: number
   /** Maximum pixel count for each rendered screenshot image. */
@@ -51,6 +53,7 @@ export interface ResolvedConfig {
   readonly gatewayMutationTimeoutMs: number
   readonly unitContentOperationTimeoutMs: number
   readonly screenshotOperationTimeoutMs: number
+  readonly printPdfOperationTimeoutMs: number
   readonly screenshotMaxPages: number
   readonly screenshotMaxPixels: number
   readonly resourceCacheRoot: string
@@ -73,6 +76,7 @@ export const Config: z<Config> = z.object({
   gatewayMutationTimeoutMs: z.natural().default(60_000),
   unitContentOperationTimeoutMs: z.natural().default(120_000),
   screenshotOperationTimeoutMs: z.natural().default(120_000),
+  printPdfOperationTimeoutMs: z.natural().default(120_000),
   screenshotMaxPages: z.natural().default(30),
   screenshotMaxPixels: z.natural().default(16_777_216),
   resourceCacheRoot: z.string(),
@@ -96,6 +100,7 @@ export function resolveConfig(config: Config = {}): ResolvedConfig {
     gatewayMutationTimeoutMs: config.gatewayMutationTimeoutMs ?? 60_000,
     unitContentOperationTimeoutMs: config.unitContentOperationTimeoutMs ?? 120_000,
     screenshotOperationTimeoutMs: config.screenshotOperationTimeoutMs ?? 120_000,
+    printPdfOperationTimeoutMs: config.printPdfOperationTimeoutMs ?? 120_000,
     screenshotMaxPages: config.screenshotMaxPages ?? 30,
     screenshotMaxPixels: config.screenshotMaxPixels ?? 16_777_216,
     resourceCacheRoot: resolveResourceCacheRoot(config.resourceCacheRoot),
@@ -121,6 +126,7 @@ export function resolveConfig(config: Config = {}): ResolvedConfig {
     gatewayMutationTimeoutMs: resolved.gatewayMutationTimeoutMs,
     unitContentOperationTimeoutMs: resolved.unitContentOperationTimeoutMs,
     screenshotOperationTimeoutMs: resolved.screenshotOperationTimeoutMs,
+    printPdfOperationTimeoutMs: resolved.printPdfOperationTimeoutMs,
     screenshotMaxPages: resolved.screenshotMaxPages,
     screenshotMaxPixels: resolved.screenshotMaxPixels,
     resourceDownloadTimeoutMs: resolved.resourceDownloadTimeoutMs,

--- a/src/host/provider/gateway-univer-service.ts
+++ b/src/host/provider/gateway-univer-service.ts
@@ -17,6 +17,7 @@ import type {
   ImportUnitContentRequest,
   InspectUnitContentRequest,
   LintUnitLayoutRequest,
+  PrintPdfUnitRequest,
   ResourceOperationRequest,
   ScreenshotServiceResult,
   ScreenshotUnitRequest,
@@ -372,6 +373,32 @@ export class GatewayUniverService extends UniverService {
       })
     )
     return { ok: true, operation: 'screenshot', file: request.file, result }
+  }
+
+  /** Print one explicit Unit from trunk or a worktree to PDF. */
+  async printUnitPdf(
+    request: PrintPdfUnitRequest,
+    signal?: AbortSignal
+  ): Promise<UniverOperationResult> {
+    await Promise.all([
+      assertAuthorizedPath(request.workspace, request.file, true),
+      assertAuthorizedPath(request.outputWorkspace, request.output, false)
+    ])
+    const gateway = await this.requireGateway()
+    const source = await this.renderSources.load(
+      gateway,
+      request.file,
+      request.unitId,
+      request.worktreeId,
+      signal
+    )
+    const result = await this.render.printPdf({
+      source,
+      output: request.output,
+      ...(signal === undefined ? {} : { signal })
+    })
+    await assertAuthorizedPath(request.outputWorkspace, result.output, true)
+    return { ok: true, operation: 'print-pdf', file: request.file, result }
   }
 
   /** Compile one SVG and commit the generated Slide mutations to a draft worktree. */

--- a/src/host/provider/render-operations.ts
+++ b/src/host/provider/render-operations.ts
@@ -1,6 +1,7 @@
+import { randomUUID } from 'node:crypto'
 import { readFileSync, realpathSync } from 'node:fs'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path'
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
+import { basename, dirname, extname, isAbsolute, relative, resolve, sep } from 'node:path'
 import {
   compileSvgToFacade,
   isSvgFacadeError,
@@ -10,6 +11,11 @@ import {
   type SvgTextMeasurer
 } from '@univer-cli/svg-facade'
 import { createUnitLayoutLint, isUnitLayoutLintError } from '@univer-cli/unit-layout-lint'
+import {
+  createUnitPdfPrinter,
+  isUnitPdfPrinterError,
+  type UnitPdfPrintInput
+} from '@univer-cli/unit-pdf-printer'
 import {
   createUnitScreenshot,
   isUnitScreenshotError,
@@ -22,6 +28,7 @@ import {
   UNIVER_RENDER_BROWSER_ENV_VAR,
   type UniverRenderRuntime,
   type UniverRenderUnit,
+  type UniverPrintPdfRuntime,
   type UniverSlideLayoutRuntime,
   type UniverTextMeasureRuntime
 } from '@univer-cli/univer-render-runtime'
@@ -36,7 +43,10 @@ import type {
 import { UniverError } from '../service/errors.ts'
 import { UNIVER_LICENSE } from '../../workers/unit-content/license.ts'
 
-type MachineRuntime = UniverRenderRuntime & UniverSlideLayoutRuntime & UniverTextMeasureRuntime
+type MachineRuntime = UniverPrintPdfRuntime &
+  UniverRenderRuntime &
+  UniverSlideLayoutRuntime &
+  UniverTextMeasureRuntime
 
 interface RenderSource {
   readonly unitType: UniverUnitKind
@@ -56,6 +66,46 @@ export interface CompiledSvgProgram {
 
 /** Browser-backed layout and authoring operations owned by the Service Provider. */
 export class RenderOperations {
+  /** Print one Unit snapshot to an authorized PDF output path. */
+  async printPdf(input: {
+    readonly source: UniverRenderUnit
+    readonly output: string
+    readonly signal?: AbortSignal
+  }): Promise<{
+    readonly output: string
+    readonly pageCount: number
+    readonly unitId: string
+    readonly unitType: Exclude<UniverUnitKind, 'base'>
+  }> {
+    if (extname(input.output).toLowerCase() !== '.pdf') {
+      throw new UniverError('PDF output path must end in .pdf.', 'UNIT_PRINT_PDF_OUTPUT_INVALID')
+    }
+    if (input.source.unitType === 'base') {
+      throw new UniverError(
+        'Base Units do not support PDF printing.',
+        'UNIT_PRINT_PDF_TYPE_UNSUPPORTED'
+      )
+    }
+    const runtime = await this.openRuntime(input.signal)
+    try {
+      const result = await createUnitPdfPrinter({ runtime }).print({
+        ...input.source,
+        ...(input.signal === undefined ? {} : { signal: input.signal })
+      } as UnitPdfPrintInput)
+      await writePdf(input.output, result.bytes, input.signal)
+      return {
+        output: input.output,
+        pageCount: result.pageCount,
+        unitId: result.unitId,
+        unitType: result.unitType
+      }
+    } catch (error) {
+      throw renderError(error)
+    } finally {
+      await runtime.close()
+    }
+  }
+
   /** Analyze one Slide snapshot without producing image output. */
   async lint(
     source: RenderSource,
@@ -313,6 +363,30 @@ function screenshotMetadata(image: ScreenshotImage): JsonValue {
   }
 }
 
+async function writePdf(output: string, bytes: Uint8Array, signal?: AbortSignal): Promise<void> {
+  await mkdir(dirname(output), { recursive: true })
+  const temporary = `${output}.${String(process.pid)}.${randomUUID()}.tmp`
+  try {
+    signal?.throwIfAborted()
+    await writeFile(temporary, bytes, signal === undefined ? undefined : { signal })
+    signal?.throwIfAborted()
+    await rename(temporary, output)
+  } catch (error) {
+    if (error instanceof UniverError) throw error
+    throw new UniverError('Failed to write PDF output.', 'UNIT_PRINT_PDF_WRITE_FAILED', {
+      cause: error
+    })
+  } finally {
+    await unlink(temporary).catch((error: unknown) => {
+      if (!isNodeError(error) || error.code !== 'ENOENT') throw error
+    })
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error
+}
+
 function assetResolver(
   workspace: string,
   source: string
@@ -413,6 +487,9 @@ function renderError(error: unknown): Error {
   }
   if (isUnitLayoutLintError(error)) {
     return new UniverError(error.message, `UNIT_LAYOUT_LINT_${error.code}`, { cause: error })
+  }
+  if (isUnitPdfPrinterError(error)) {
+    return new UniverError(error.message, `UNIT_PRINT_PDF_${error.code}`, { cause: error })
   }
   if (isUnitScreenshotError(error)) {
     return new UniverError(error.message, `SCREENSHOT_${error.code}`, { cause: error })

--- a/src/host/service/types.ts
+++ b/src/host/service/types.ts
@@ -142,6 +142,14 @@ export interface ScreenshotUnitRequest extends ScopedFileRequest {
   readonly target?: ScreenshotTarget
 }
 
+/** Request for printing one Unit to an authorized workspace PDF file. */
+export interface PrintPdfUnitRequest extends ScopedFileRequest {
+  readonly unitId: UnitId
+  readonly worktreeId?: WorktreeId
+  readonly output: string
+  readonly outputWorkspace: WorkspacePath
+}
+
 /** One PNG returned to the Tools Consumer before attachment persistence. */
 export interface ScreenshotServiceImage {
   readonly data: string
@@ -222,6 +230,7 @@ export interface UniverOperationResult {
     | 'export'
     | 'lint'
     | 'screenshot'
+    | 'print-pdf'
     | 'compile-svg'
     | 'unit'
     | 'worktree'
@@ -271,6 +280,7 @@ export interface UniverServiceMethods {
     request: ScreenshotUnitRequest,
     signal?: AbortSignal
   ): Promise<ScreenshotServiceResult>
+  printUnitPdf(request: PrintPdfUnitRequest, signal?: AbortSignal): Promise<UniverOperationResult>
   compileSvg(request: CompileSvgRequest, signal?: AbortSignal): Promise<UniverOperationResult>
   apiReference(request: ApiReferenceRequest): Promise<UniverApiResult>
   resources(request: ResourceOperationRequest, signal?: AbortSignal): Promise<UniverResourceResult>

--- a/src/host/service/univer-service.ts
+++ b/src/host/service/univer-service.ts
@@ -53,6 +53,9 @@ export abstract class UniverService extends Service implements UniverServiceMeth
   abstract screenshotUnit(
     ...args: Parameters<UniverServiceMethods['screenshotUnit']>
   ): ReturnType<UniverServiceMethods['screenshotUnit']>
+  abstract printUnitPdf(
+    ...args: Parameters<UniverServiceMethods['printUnitPdf']>
+  ): ReturnType<UniverServiceMethods['printUnitPdf']>
   abstract compileSvg(
     ...args: Parameters<UniverServiceMethods['compileSvg']>
   ): ReturnType<UniverServiceMethods['compileSvg']>

--- a/src/host/tools/definitions/print-pdf.ts
+++ b/src/host/tools/definitions/print-pdf.ts
@@ -1,0 +1,60 @@
+import type { Context } from '@deepseek-ai/cordis'
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import { unitId, worktreeId } from '../../service/identifiers.ts'
+import { operationOutput, operationTitle } from '../presentation.ts'
+import { existingToolFile, newToolPath } from '../workspace.ts'
+
+/** Create the `univer_print_pdf` tool definition. */
+export function printPdfTool(ctx: Context, timeoutMs: number) {
+  return defineTool({
+    name: 'univer_print_pdf',
+    description:
+      'Print one explicit Sheet, Doc, Slide, or Board Unit from trunk or a worktree to a workspace PDF file. Base Units are not printable.',
+    timeoutMs,
+    parameters: {
+      file: {
+        type: 'string',
+        required: true,
+        description: 'Workspace-relative or absolute .univer path.'
+      },
+      output: {
+        type: 'string',
+        required: true,
+        description: 'Workspace-relative or absolute .pdf output file path.'
+      },
+      unitId: {
+        type: 'string',
+        required: true,
+        description: 'Explicit Unit id from univer_status.'
+      },
+      worktreeId: {
+        type: 'string',
+        description: 'Optional worktree scope; omit to print trunk.'
+      }
+    },
+    output: operationOutput,
+    async execute(args, exec) {
+      const [target, output] = await Promise.all([
+        existingToolFile(exec, args.file),
+        newToolPath(exec, args.output)
+      ])
+      return ctx.univer.printUnitPdf(
+        {
+          workspace: target.workspace,
+          file: target.path,
+          outputWorkspace: output.workspace,
+          output: output.path,
+          unitId: unitId(args.unitId),
+          ...(args.worktreeId === undefined ? {} : { worktreeId: worktreeId(args.worktreeId) })
+        },
+        exec.signal
+      )
+    },
+    presentCall: (args) => ({
+      card: 'generic',
+      title: operationTitle('print PDF', args.file),
+      kind: 'execute',
+      locations: [{ path: args.output }]
+    })
+  })
+}

--- a/src/host/tools/plugin.ts
+++ b/src/host/tools/plugin.ts
@@ -8,6 +8,7 @@ import { exportTool } from './definitions/export.ts'
 import { importTool } from './definitions/import.ts'
 import { inspectTool } from './definitions/inspect.ts'
 import { lintTool } from './definitions/lint.ts'
+import { printPdfTool } from './definitions/print-pdf.ts'
 import { newTool } from './definitions/new.ts'
 import { resourcesTool } from './definitions/resources.ts'
 import { screenshotTool } from './definitions/screenshot.ts'
@@ -25,6 +26,7 @@ export function apply(ctx: Context, config: ResolvedConfig): void {
   const gatewayWriteTimeoutMs = config.gatewayStartupTimeoutMs + config.gatewayMutationTimeoutMs
   const unitContentTimeoutMs = config.gatewayStartupTimeoutMs + config.unitContentOperationTimeoutMs
   const screenshotTimeoutMs = config.gatewayStartupTimeoutMs + config.screenshotOperationTimeoutMs
+  const printPdfTimeoutMs = config.gatewayStartupTimeoutMs + config.printPdfOperationTimeoutMs
   ctx.tools.register(withUniverErrorContent(newTool(ctx, gatewayWriteTimeoutMs)))
   ctx.tools.register(withUniverErrorContent(statusTool(ctx, gatewayReadTimeoutMs)))
   ctx.tools.register(withUniverErrorContent(worktreeTool(ctx, gatewayWriteTimeoutMs)))
@@ -34,6 +36,7 @@ export function apply(ctx: Context, config: ResolvedConfig): void {
   ctx.tools.register(withUniverErrorContent(executeTool(ctx, unitContentTimeoutMs)))
   ctx.tools.register(withUniverErrorContent(exportTool(ctx, unitContentTimeoutMs)))
   ctx.tools.register(withUniverErrorContent(lintTool(ctx, unitContentTimeoutMs)))
+  ctx.tools.register(withUniverErrorContent(printPdfTool(ctx, printPdfTimeoutMs)))
   ctx.tools.register(withUniverErrorContent(compileSvgTool(ctx, unitContentTimeoutMs)))
   // A screenshot result must durably reference image bytes; advertise the tool only while
   // the deployment has an attachment store, and keep the execution-time re-check defensive.

--- a/src/host/tools/presentation.ts
+++ b/src/host/tools/presentation.ts
@@ -20,6 +20,7 @@ export const operationOutput = {
           'export',
           'lint',
           'screenshot',
+          'print-pdf',
           'compile-svg',
           'unit',
           'worktree'

--- a/src/viewer-support/render-preset/index.ts
+++ b/src/viewer-support/render-preset/index.ts
@@ -321,6 +321,13 @@ function registerOutputPlugins(
   }
 }
 
+function registerAllPrintPlugins(univer: Univer): void {
+  univer.registerPlugin(UniverSheetsPrintPlugin)
+  univer.registerPlugin(UniverDocsPrintPlugin)
+  univer.registerPlugin(UniverSlidesPrintPlugin)
+  univer.registerPlugin(UniverBoardsPrintPlugin)
+}
+
 function registerEmbedCorePlugin(
   univer: Univer,
   resourceRefDataProviderRegistrations: readonly IEmbedResourceRefDataProviderRegistration[]
@@ -384,6 +391,8 @@ export function registerViewRendering(univer: Univer, options: ViewRenderingOpti
   options.registerBeforeEmbedCore?.()
   if (options.unitType !== undefined) {
     registerOutputPlugins(univer, options.unitType, options.exchangeClientConfig)
+  } else {
+    registerAllPrintPlugins(univer)
   }
   registerEmbedCorePlugin(univer, options.resourceRefDataProviderRegistrations ?? [])
   options.registerAfterEmbedCore?.()

--- a/test/host-smoke.mjs
+++ b/test/host-smoke.mjs
@@ -19,6 +19,9 @@ if (defaultConfig.gatewayPort !== 9080)
 if (defaultConfig.screenshotMaxPages !== 30 || defaultConfig.screenshotMaxPixels !== 16_777_216) {
   throw new Error(`default screenshot limits drifted: ${JSON.stringify(defaultConfig)}`)
 }
+if (defaultConfig.printPdfOperationTimeoutMs !== 120_000) {
+  throw new Error(`default PDF print timeout drifted: ${JSON.stringify(defaultConfig)}`)
+}
 if (!defaultConfig.resourceCacheRoot.endsWith(join('cache', 'dsh-univer-office', 'resources'))) {
   throw new Error(`default resource cache root drifted: ${defaultConfig.resourceCacheRoot}`)
 }
@@ -39,7 +42,11 @@ try {
 } catch (error) {
   if (!(error instanceof Error) || !error.message.includes('gatewayPort')) throw error
 }
-for (const invalid of [{ screenshotMaxPages: 0 }, { resourceCacheRoot: 'relative/cache' }]) {
+for (const invalid of [
+  { screenshotMaxPages: 0 },
+  { printPdfOperationTimeoutMs: 0 },
+  { resourceCacheRoot: 'relative/cache' }
+]) {
   try {
     resolveConfig(invalid)
     throw new Error(`invalid config must be rejected: ${JSON.stringify(invalid)}`)
@@ -390,6 +397,15 @@ try {
     agent: owner
   })
   assertToolError(screenshotResult, 'GATEWAY_UNAVAILABLE')
+
+  const printPdfResult = await toolContext.tools.execute({
+    signal: new AbortController().signal,
+    callId: ToolCallId('host-smoke-print-pdf'),
+    name: 'univer_print_pdf',
+    arguments: { file: FILE, unitId: 'unit-1', output: 'report.pdf' },
+    agent: owner
+  })
+  assertToolError(printPdfResult, 'GATEWAY_UNAVAILABLE')
 
   const missingToolResult = await toolContext.tools.execute({
     signal: new AbortController().signal,

--- a/test/integration-smoke.mjs
+++ b/test/integration-smoke.mjs
@@ -40,6 +40,7 @@ const source = join(workspace, 'import.csv')
 const svgSource = join(workspace, 'slide.svg')
 const exported = join(workspace, 'smoke.xlsx')
 const screenshotOutput = join(workspace, 'screenshots')
+const printedPdf = join(workspace, 'rendered.pdf')
 const resourceOutput = join(workspace, 'resources')
 await writeFile(source, 'name,value\nalpha,1\nbeta,2\n')
 await writeFile(
@@ -216,6 +217,39 @@ try {
   for (const image of screenshot.result.images) {
     if ((await stat(image.path)).size === 0)
       throw new Error(`screenshot produced an empty file: ${image.path}`)
+  }
+
+  const printed = await service.printUnitPdf({
+    ...scoped,
+    worktreeId,
+    unitId: slideUnitId,
+    output: printedPdf,
+    outputWorkspace: workspace
+  })
+  if (
+    printed.operation !== 'print-pdf' ||
+    printed.result?.unitId !== slideUnitId ||
+    printed.result?.unitType !== 'slide' ||
+    printed.result?.pageCount !== 1 ||
+    printed.result?.output !== printedPdf
+  ) {
+    throw new Error(`Slide PDF print failed: ${JSON.stringify(printed)}`)
+  }
+  const pdfBytes = await readFile(printedPdf)
+  if (pdfBytes.byteLength === 0 || pdfBytes.subarray(0, 5).toString() !== '%PDF-') {
+    throw new Error('Slide PDF print did not produce a real PDF file')
+  }
+  try {
+    await service.printUnitPdf({
+      ...scoped,
+      worktreeId,
+      unitId: baseUnitId,
+      output: join(workspace, 'base.pdf'),
+      outputWorkspace: workspace
+    })
+    throw new Error('Base PDF printing must be rejected')
+  } catch (error) {
+    if (error?.code !== 'UNIT_PRINT_PDF_TYPE_UNSUPPORTED') throw error
   }
 
   const executed = await service.executeUnitContent({
@@ -535,7 +569,7 @@ try {
   }
 
   console.log(
-    'integration smoke OK (new/status/Unit/import/API/execute/5-Unit History/Sheet/Base/Board inspect/export/lint/compile-svg/screenshot/resources/Worktree lifecycle, no global CLI)'
+    'integration smoke OK (new/status/Unit/import/API/execute/5-Unit History/Sheet/Base/Board inspect/export/lint/compile-svg/screenshot/print-pdf/resources/Worktree lifecycle, no global CLI)'
   )
 } finally {
   await service.dispose()

--- a/test/skills-smoke.mjs
+++ b/test/skills-smoke.mjs
@@ -39,6 +39,7 @@ if (
   core === undefined ||
   !core.content.includes('univer_status') ||
   !core.content.includes('univer_screenshot') ||
+  !core.content.includes('univer_print_pdf') ||
   !core.content.includes('univer_resources') ||
   !core.content.includes('await import("node:fs/promises")') ||
   !core.content.includes('codeFile') ||


### PR DESCRIPTION
## Summary

- add the univer_print_pdf tool and service/provider path for Sheet, Doc, Slide, and Board Units
- register print plugins in the multi-Unit render machine and enforce authorized PDF output paths
- add timeout configuration, documentation, skill guidance, and integration coverage

## Testing

- pnpm run typecheck
- pnpm run lint
- pnpm run format:check
- pnpm run test
- pnpm run verify:public-dependencies
- integration smoke generated a real one-page Slide PDF, verified its %PDF- signature, and verified Base rejection