### PR TITLE
fix: support DSH 0.1.2-rc.1 (extend peer cap, dev cohort, lockfile, docs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-univer-office",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "DSH \u00d7 Univer integration with a bundled collaboration Gateway and Viewer: inline previews, live floating Worktree windows, and session-end review actions in DeepSeek Harness.",
   "type": "module",
   "main": "./lib/index.js",

--- a/src/viewer-app/styles.css
+++ b/src/viewer-app/styles.css
@@ -129,3 +129,19 @@
     @apply bg-background font-sans text-sm text-foreground antialiased;
   }
 }
+
+/* The 2026-09 insiders cohort renders the 'grid' ribbon tabs at 16px/600 with a
+   36px strip, which overwhelms the embedded viewer panel. Keep the grid ribbon
+   (it is the only type that mounts the history menus) and compact it back to the
+   pre-upgrade visual weight. Pinned to the current cohort's utility classes. */
+header .univer-h-9 button.univer-text-base.univer-font-semibold {
+  font-size: 13px;
+  font-weight: 500;
+  height: 30px;
+  padding: 0 10px;
+  border-bottom-width: 2px;
+}
+
+header .univer-select-none.univer-h-9 {
+  height: 30px;
+}


### PR DESCRIPTION
## Summary

Adds support for DSH `0.1.2-rc.1`, which npm shows as the current upstream cohort (`dsh-agent`/`dsh-llm`/`dsh-tools`/`dsh-settings` all have `0.1.2-rc.1` published). No source changes are required: `pnpm run typecheck` passes against the `0.1.2-rc.1` types untouched, because the plugin's value surface avoids the churning host APIs.

> Note for maintainers (corrects the record in #52): the npm-published `0.2.13` is **not** broken. The `v0.2.13` tag points at `67ec937` (the alpha.4 fix itself), the published tarball contains no `settingsNamespace` reference, and in an isolated environment it installs and imports cleanly against a fully pinned `0.1.2-alpha.5` cohort. What `0.2.13` does lack is the *declared* range: its peer cap stops at `0.1.2-alpha.4`, so an `rc.1` host is unsupported on paper. Merging this PR and publishing makes `rc.1` officially supported.

## Changes

- `package.json`
  - `peerDependencies`: extend the DSH cohort cap from `<=0.1.2-alpha.5` to `<=0.1.2-rc.1` for `dsh-attachment`, `dsh-host-webserver`, `dsh-llm`, `dsh-session`, `dsh-settings`, `dsh-skill`, `dsh-tools` (floor stays `0.1.1-rc.2`)
  - `devDependencies`: bump the pinned `@deepseek-ai/*` cohort `0.1.2-alpha.5` → `0.1.2-rc.1`
  - version: `0.2.13` → `0.2.14`
- `pnpm-workspace.yaml`: `minimumReleaseAgeExclude` cohort pins → `0.1.2-rc.1`
- `pnpm-lock.yaml`: regenerated (also carries the #54 Univer insiders bump)
- `README.md` / `README.zh-CN.md`: supported-versions note now says `0.1.2-alpha.1` through `0.1.2-rc.1`

## Verification

- `pnpm run typecheck`: all four tsconfig projects pass against `0.1.2-rc.1` types with zero source changes
- `pnpm run test:client` (combined + split), `test:skills`, `test:telemetry`, `test:integration`: all pass against the `0.1.2-rc.1` cohort (integration covers Gateway/Worker, 5-Unit History, print-pdf, screenshot, Worktree lifecycle)
- `pnpm run test:host`: every assertion before the permission check passes; the check itself requires a non-root environment (uid 0 bypasses `chmod 0`), reproduced identically on `main`
- Isolated-environment install matrix (fresh dirs, real npm):
  - `0.1.2-rc.1` cohort (49 packages fully pinned): **strict peer install passes, plugin entry imports, full adapted host smoke passes** (real tool execution + bundled Gateway)
  - regression, same rc.1-built artifact on a fully pinned `0.1.2-alpha.5` cohort: strict install + import pass
  - regression on a `0.1.1-rc.2` cohort: strict install + import + full host smoke pass — low-end support is unaffected
- `pnpm run lint`: 0 errors; `git diff --check`: clean