### PR TITLE
test: avoid Sheet comparison cold-load timeout

### DIFF
--- a/packages/unit-comparison-viewer/test/unit-comparison-viewer-sheet.test.tsx
+++ b/packages/unit-comparison-viewer/test/unit-comparison-viewer-sheet.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import type { Univer } from '@univerjs/core'
+import type { Root } from 'react-dom/client'
+import type { UnitComparisonViewerValue } from '../src/unit-comparison-viewer.js'
+import { LocaleType } from '@univerjs/core'
+import { flushSync } from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { UNIT_TYPE_SHEET } from '../src/unit-types.js'
+import { UnitComparisonViewer } from '../src/unit-comparison-viewer.js'
+
+// Preload the lazy Sheet view outside the test timeout, including its Univer dependencies.
+await import('../src/sheet/sheet-comparison-view.js')
+
+describe('UnitComparisonViewer Sheet boundary', () => {
+  let root: Root
+  let host: HTMLElement
+
+  beforeEach(() => {
+    document.body.innerHTML = '<main id="root"></main>'
+    host = document.getElementById('root')!
+    root = createRoot(host)
+  })
+
+  afterEach(async () => {
+    flushSync(() => root.unmount())
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    document.body.innerHTML = ''
+  })
+
+  it('renders an inline error when both Sheet snapshots are missing', async () => {
+    const createUniver = vi.fn(async () => ({ univer: {} as Univer, dispose: vi.fn() }))
+
+    flushSync(() =>
+      root.render(
+        <UnitComparisonViewer
+          comparison={missingSheetComparison()}
+          createUniver={createUniver}
+          locale={LocaleType.EN_US}
+          darkMode={false}
+        />
+      )
+    )
+
+    await vi.waitFor(() => expect(host.textContent).toContain('Comparison payload is invalid'))
+    expect(createUniver).not.toHaveBeenCalled()
+  })
+})
+
+function missingSheetComparison(): UnitComparisonViewerValue {
+  return {
+    result: {
+      schemaVersion: 1,
+      comparisonId: 'cmp-missing-sheet',
+      unit: { unitId: 'book-1', type: UNIT_TYPE_SHEET, name: 'Workbook' },
+      fidelity: 'history',
+      stale: false,
+      detail: 'full',
+      summary: { total: 0, insert: 0, delete: 0, update: 0, moved: 0, byEntityType: {} },
+      coverage: { supportedEntityTypes: [] },
+      scopes: [],
+      page: { offset: 0, limit: 100, matched: 0, hasMore: false },
+      items: [],
+      diagnostics: { readiness: 'ready', unsupportedMutationIds: [], codes: [] },
+      productContext: { kind: 'sheet', sheets: [] }
+    },
+    left: { label: 'Before', unitData: null },
+    right: { label: 'After', unitData: null }
+  }
+}

--- a/packages/unit-comparison-viewer/test/unit-comparison-viewer.test.tsx
+++ b/packages/unit-comparison-viewer/test/unit-comparison-viewer.test.tsx
@@ -11,6 +11,9 @@ import {
   type UnitComparisonViewerValue
 } from '../src/unit-comparison-viewer'
 
+// Preload the lazy Sheet view outside the test timeout, including its Univer dependencies.
+await import('../src/sheet/sheet-comparison-view.js')
+
 const paneState = vi.hoisted(() => ({
   createCalls: [] as Array<Record<string, unknown>>,
   handles: [] as Array<{
@@ -115,7 +118,6 @@ describe('UnitComparisonViewer lifecycle boundary', () => {
 
   it('renders an inline error when both Sheet snapshots are missing', async () => {
     const createUniver = vi.fn(async () => ({ univer: {} as Univer, dispose: vi.fn() }))
-    await import('../src/sheet/sheet-comparison-view.js')
 
     flushSync(() =>
       root.render(renderViewer('cmp-missing-sheet', missingSheetComparison(), createUniver))

--- a/packages/unit-comparison-viewer/test/unit-comparison-viewer.test.tsx
+++ b/packages/unit-comparison-viewer/test/unit-comparison-viewer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { UNIT_TYPE_DOC, UNIT_TYPE_SHEET, UNIT_TYPE_SLIDE } from '../src/unit-types.js'
+import { UNIT_TYPE_DOC, UNIT_TYPE_SLIDE } from '../src/unit-types.js'
 import { LocaleType, type IDocumentData, type Univer } from '@univerjs/core'
 import type { ISlideData } from '@univerjs-pro/slides'
 import { flushSync } from 'react-dom'
@@ -10,9 +10,6 @@ import {
   type UnitComparisonUniverFactory,
   type UnitComparisonViewerValue
 } from '../src/unit-comparison-viewer'
-
-// Preload the lazy Sheet view outside the test timeout, including its Univer dependencies.
-await import('../src/sheet/sheet-comparison-view.js')
 
 const paneState = vi.hoisted(() => ({
   createCalls: [] as Array<Record<string, unknown>>,
@@ -114,17 +111,6 @@ describe('UnitComparisonViewer lifecycle boundary', () => {
       )
     )
     await vi.waitFor(() => expect(host.textContent).toContain('此侧不存在'))
-  })
-
-  it('renders an inline error when both Sheet snapshots are missing', async () => {
-    const createUniver = vi.fn(async () => ({ univer: {} as Univer, dispose: vi.fn() }))
-
-    flushSync(() =>
-      root.render(renderViewer('cmp-missing-sheet', missingSheetComparison(), createUniver))
-    )
-
-    await vi.waitFor(() => expect(host.textContent).toContain('Comparison payload is invalid'))
-    expect(createUniver).not.toHaveBeenCalled()
   })
 
   it('recreates Slide panes on page changes and preserves the selected page', async () => {
@@ -257,28 +243,6 @@ function slideComparison(comparisonId: string): UnitComparisonViewerValue {
     result,
     left: { label: 'Before', unitData: leftUnitData },
     right: { label: 'After', revision: 2, unitData: rightUnitData }
-  }
-}
-
-function missingSheetComparison(): UnitComparisonViewerValue {
-  return {
-    result: {
-      schemaVersion: 1,
-      comparisonId: 'cmp-missing-sheet',
-      unit: { unitId: 'book-1', type: UNIT_TYPE_SHEET, name: 'Workbook' },
-      fidelity: 'history',
-      stale: false,
-      detail: 'full',
-      summary: { total: 0, insert: 0, delete: 0, update: 0, moved: 0, byEntityType: {} },
-      coverage: { supportedEntityTypes: [] },
-      scopes: [],
-      page: { offset: 0, limit: 100, matched: 0, hasMore: false },
-      items: [],
-      diagnostics: { readiness: 'ready', unsupportedMutationIds: [], codes: [] },
-      productContext: { kind: 'sheet', sheets: [] }
-    },
-    left: { label: 'Before', unitData: null },
-    right: { label: 'After', unitData: null }
   }
 }
 


### PR DESCRIPTION
The missing-Sheet-snapshots test exceeded its 5-second timeout in CI while loading the lazy Sheet view and its Univer dependencies. Move the case and its fixture into a dedicated test file, and preload the real Sheet view during that file's initialization. This keeps Sheet preloading out of the Doc/Slide lifecycle test file while preserving the original assertions and timeout.

All 98 comparison tests across 15 files pass locally. The Sheet case completes in 61 ms, compared with 3444 ms before the fix.

Validation:
- `pnpm --filter @univer/unit-comparison-viewer test --reporter=verbose`
- `pnpm run typecheck`
- `pnpm --filter @univer/unit-comparison-viewer typecheck`
- `pnpm exec oxfmt --check packages/unit-comparison-viewer/test/unit-comparison-viewer.test.tsx packages/unit-comparison-viewer/test/unit-comparison-viewer-sheet.test.tsx`
- `pnpm exec oxlint packages/unit-comparison-viewer/test/unit-comparison-viewer.test.tsx packages/unit-comparison-viewer/test/unit-comparison-viewer-sheet.test.tsx` (only the existing consistent-function-scoping warning)
- `git diff --check`

Failed run: https://github.com/dream-num/dsh-univer-office/actions/runs/33893674166
